### PR TITLE
remove dead link to maven plugin repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,10 +53,6 @@
             <name>Local Repository 2</name>
             <url>file:../repo</url>
         </pluginRepository>
-        <pluginRepository>
-            <id>Codehaus Repository</id>
-            <url>http://repository.codehaus.org/</url>
-        </pluginRepository>
     </pluginRepositories>
 
     <scm>


### PR DESCRIPTION
If I clone libresonic and try running `mvn package` on the release branch, I get errors complaining about invalid checksums on maven-plugin-dependency.pom. Turns out, my DNS server resolves non-existent domains to its own server. Maven downloads an html page that is not the actual maven-plugin-dependency.pom, so fails.

After removing the non-existent link, maven chooses a correct repository server to get packages from.