### PR TITLE
Revert JAXBWriter for SubsonicResponse in REST API schema

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/controller/JAXBWriter.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/JAXBWriter.java
@@ -134,7 +134,7 @@ public class JAXBWriter {
             if (jsonp) {
                 writer.append(jsonpCallback).append('(');
             }
-            marshaller.marshal(new ObjectFactory().createLibresonicResponse(jaxbResponse), writer);
+            marshaller.marshal(new ObjectFactory().createSubsonicResponse(jaxbResponse), writer);
             if (jsonp) {
                 writer.append(");");
             }


### PR DESCRIPTION
Fix an issue with compilation introduced by 2cd4f34.

Revert the JAXBWriter to using SubsonicRespnse instead of LibresonicResponse.