### PR TITLE
Fixed parent artifact name

### DIFF
--- a/subsonic-assembly/pom.xml
+++ b/subsonic-assembly/pom.xml
@@ -9,7 +9,7 @@
 
     <parent>
         <groupId>net.sourceforge.subsonic</groupId>
-        <artifactId>subsonic</artifactId>
+        <artifactId>libresonic</artifactId>
         <version>6.0.1</version>
     </parent>
 

--- a/subsonic-booter/pom.xml
+++ b/subsonic-booter/pom.xml
@@ -8,7 +8,7 @@
 
     <parent>
         <groupId>net.sourceforge.subsonic</groupId>
-        <artifactId>subsonic</artifactId>
+        <artifactId>libresonic</artifactId>
         <version>6.0.1</version>
     </parent>
 

--- a/subsonic-installer-debian/pom.xml
+++ b/subsonic-installer-debian/pom.xml
@@ -9,7 +9,7 @@
 
     <parent>
         <groupId>net.sourceforge.subsonic</groupId>
-        <artifactId>subsonic</artifactId>
+        <artifactId>libresonic</artifactId>
         <version>6.0.1</version>
     </parent>
 

--- a/subsonic-installer-mac/pom.xml
+++ b/subsonic-installer-mac/pom.xml
@@ -9,7 +9,7 @@
 
     <parent>
         <groupId>net.sourceforge.subsonic</groupId>
-        <artifactId>subsonic</artifactId>
+        <artifactId>libresonic</artifactId>
         <version>6.0.1</version>
     </parent>
 

--- a/subsonic-installer-rpm/pom.xml
+++ b/subsonic-installer-rpm/pom.xml
@@ -9,7 +9,7 @@
 
     <parent>
         <groupId>net.sourceforge.subsonic</groupId>
-        <artifactId>subsonic</artifactId>
+        <artifactId>libresonic</artifactId>
         <version>6.0.1</version>
     </parent>
 

--- a/subsonic-installer-windows/pom.xml
+++ b/subsonic-installer-windows/pom.xml
@@ -9,7 +9,7 @@
 
     <parent>
         <groupId>net.sourceforge.subsonic</groupId>
-        <artifactId>subsonic</artifactId>
+        <artifactId>libresonic</artifactId>
         <version>6.0.1</version>
     </parent>
 


### PR DESCRIPTION
I'm unfamiliar with maven but libresonic was failing to compile when attempting to build a deb. A little digging and I found the artifactId in the pom files was incorrect. After making these changes it successfully compiled on debian 8.