### PR TITLE
Disable URL redirection

### DIFF
--- a/libresonic-main/pom.xml
+++ b/libresonic-main/pom.xml
@@ -279,6 +279,7 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- UPNP / DLNA -->
         <dependency>
             <groupId>org.fourthline.cling</groupId>
             <artifactId>cling-core</artifactId>
@@ -293,8 +294,14 @@
 
         <dependency>
             <groupId>org.seamless</groupId>
+            <artifactId>seamless-http</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seamless</groupId>
             <artifactId>seamless-util</artifactId>
-            <version>1.0-alpha2</version>
+            <version>1.1.0</version>
         </dependency>
 
         <dependency>
@@ -309,6 +316,7 @@
             <version>0.1.2</version>
         </dependency>
 
+        <!-- SONOS API / WSDL SUPPORT -->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>

--- a/libresonic-main/src/main/java/org/libresonic/player/service/NetworkService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/NetworkService.java
@@ -100,6 +100,17 @@ public class NetworkService {
      * @param test Whether to test that the redirection works.
      */
     public synchronized void initUrlRedirection(boolean test) {
+
+        if (true) {
+            // This feature isn't currently supported, since it's a public service of subsonic.org
+            // Display a warning message for now
+            boolean enabled = settingsService.isUrlRedirectionEnabled() && settingsService.getUrlRedirectType() == UrlRedirectType.NORMAL;
+            if (enabled) {
+                LOG.warn("The URL redirection service is currently not enabled!");
+            }
+            return;
+        }
+
         urlRedirectionStatus.setText("Idle");
         if (urlRedirectionFuture != null) {
             urlRedirectionFuture.cancel(true);

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_en.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_en.properties
@@ -427,6 +427,8 @@ networksettings.urlredirectionenabled = Access your server over the Internet usi
 networksettings.status = Status:
 networksettings.normalurl = Use
 networksettings.customurl = Use custom URL (advanced)
+networksettings.urlRedirectDisabled = Feature not currently available
+
 
 # transcodingSettings.jsp
 transcodingsettings.name = Name

--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/networkSettings.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/networkSettings.jsp
@@ -30,7 +30,7 @@
             var custom = $("#urlRedirectTypeCustom").is(":checked");
 
             $("#urlRedirectFrom").prop("disabled", !urlRedirectionEnabled || !normal);
-            $("#urlRedirectCustomUrl").prop("disabled", !urlRedirectionEnabled || !custom);
+            $("#urlRedirectCustomUrl").prop("disabled", !urlRedirectionEnabled || !custom);
             $("#urlRedirectTypeNormal").prop("disabled", !urlRedirectionEnabled);
             $("#urlRedirectTypeCustom").prop("disabled", !urlRedirectionEnabled);
         }
@@ -75,7 +75,7 @@
         <p>
             <form:radiobutton id="urlRedirectTypeNormal" path="urlRedirectType" value="NORMAL" onclick="enableUrlRedirectionFields()"/>
             <label for="urlRedirectTypeNormal"><fmt:message key="networksettings.normalurl"/></label>
-            http://<form:input id="urlRedirectFrom" path="urlRedirectFrom" size="16" cssStyle="margin-left:0.25em"/>.libresonic.org
+            http://<form:input id="urlRedirectFrom" path="urlRedirectFrom" size="16" cssStyle="margin-left:0.25em"/>.libresonic.org (<fmt:message key="networksettings.urlRedirectDisabled"/>)
         </p>
 
         <p>


### PR DESCRIPTION
This disables a public service provided by subsonic.org. Currently just short-circuits the relevant code and shows a warning in the UI and the logs that the feature is not available.

I vote to remove it completely but want to see what others think...