### PR TITLE
Add home page refresh delay preference

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/command/PersonalSettingsCommand.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/command/PersonalSettingsCommand.java
@@ -57,6 +57,7 @@ public class PersonalSettingsCommand {
     private boolean songNotificationEnabled;
     private boolean queueFollowingSongs;
     private boolean lastFmEnabled;
+    private int listReloadDelay;
     private String lastFmUsername;
     private String lastFmPassword;
     private boolean isReloadNeeded;
@@ -235,6 +236,14 @@ public class PersonalSettingsCommand {
 
     public void setLastFmEnabled(boolean lastFmEnabled) {
         this.lastFmEnabled = lastFmEnabled;
+    }
+
+    public int getListReloadDelay() {
+        return listReloadDelay;
+    }
+
+    public void setListReloadDelay(int listReloadDelay) {
+        this.listReloadDelay = listReloadDelay;
     }
 
     public String getLastFmUsername() {

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/HomeController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/HomeController.java
@@ -76,8 +76,8 @@ public class HomeController extends ParameterizableViewController {
         }
         int listOffset = getIntParameter(request, "listOffset", 0);
         AlbumListType listType = AlbumListType.fromId(getStringParameter(request, "listType"));
+        UserSettings userSettings = settingsService.getUserSettings(user.getUsername());
         if (listType == null) {
-            UserSettings userSettings = settingsService.getUserSettings(user.getUsername());
             listType = userSettings.getDefaultAlbumList();
         }
 
@@ -140,6 +140,7 @@ public class HomeController extends ParameterizableViewController {
         map.put("coverArtSize", CoverArtScheme.MEDIUM.getSize());
         map.put("listOffset", listOffset);
         map.put("musicFolder", selectedMusicFolder);
+        map.put("listReloadDelay", userSettings.getListReloadDelay());
 
         ModelAndView result = super.handleRequestInternal(request, response);
         result.addObject("model", map);

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/MultiController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/MultiController.java
@@ -239,6 +239,7 @@ public class MultiController extends MultiActionController {
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("showRight", userSettings.isShowNowPlayingEnabled() || userSettings.isShowChatEnabled());
         map.put("autoHidePlayQueue", userSettings.isAutoHidePlayQueue());
+        map.put("listReloadDelay", userSettings.getListReloadDelay());
         map.put("showSideBar", userSettings.isShowSideBar());
         map.put("brand", settingsService.getBrand());
         return new ModelAndView("index", "model", map);

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/PersonalSettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/PersonalSettingsController.java
@@ -73,6 +73,7 @@ public class PersonalSettingsController extends SimpleFormController {
         command.setBetaVersionNotificationEnabled(userSettings.isBetaVersionNotificationEnabled());
         command.setSongNotificationEnabled(userSettings.isSongNotificationEnabled());
         command.setAutoHidePlayQueue(userSettings.isAutoHidePlayQueue());
+        command.setListReloadDelay(userSettings.getListReloadDelay());
         command.setLastFmEnabled(userSettings.isLastFmEnabled());
         command.setLastFmUsername(userSettings.getLastFmUsername());
         command.setLastFmPassword(userSettings.getLastFmPassword());
@@ -135,6 +136,7 @@ public class PersonalSettingsController extends SimpleFormController {
         settings.setBetaVersionNotificationEnabled(command.isBetaVersionNotificationEnabled());
         settings.setSongNotificationEnabled(command.isSongNotificationEnabled());
         settings.setAutoHidePlayQueue(command.isAutoHidePlayQueue());
+        settings.setListReloadDelay(command.getListReloadDelay());
         settings.setLastFmEnabled(command.isLastFmEnabled());
         settings.setLastFmUsername(command.getLastFmUsername());
         settings.setSystemAvatarId(getSystemAvatarId(command));

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/HsqlDaoHelper.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/HsqlDaoHelper.java
@@ -52,6 +52,7 @@ import org.libresonic.player.dao.schema.hsql.Schema50;
 import org.libresonic.player.dao.schema.hsql.Schema51;
 import org.libresonic.player.dao.schema.hsql.Schema52;
 import org.libresonic.player.dao.schema.hsql.Schema53;
+import org.libresonic.player.dao.schema.hsql.Schema61;
 import org.libresonic.player.service.SettingsService;
 
 /**
@@ -67,7 +68,7 @@ public class HsqlDaoHelper implements DaoHelper {
                                 new Schema30(), new Schema31(), new Schema32(), new Schema33(), new Schema34(),
                                 new Schema35(), new Schema36(), new Schema37(), new Schema38(), new Schema40(),
                                 new Schema43(), new Schema45(), new Schema46(), new Schema47(), new Schema49(),
-                                new Schema50(), new Schema51(), new Schema52(), new Schema53()};
+                                new Schema50(), new Schema51(), new Schema52(), new Schema53(), new Schema61()};
     private DataSource dataSource;
     private static boolean shutdownHookAdded;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/UserDao.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/UserDao.java
@@ -49,7 +49,7 @@ public class UserDao extends AbstractDao {
             "playlist_year, playlist_bit_rate, playlist_duration, playlist_format, playlist_file_size, " +
             "last_fm_enabled, last_fm_username, last_fm_password, transcode_scheme, show_now_playing, selected_music_folder_id, " +
             "party_mode_enabled, now_playing_allowed, avatar_scheme, system_avatar_id, changed, show_chat, show_artist_info, auto_hide_play_queue, " +
-            "view_as_list, default_album_list, queue_following_songs, show_side_bar";
+            "view_as_list, default_album_list, queue_following_songs, show_side_bar, list_reload_delay";
 
     private static final Integer ROLE_ID_ADMIN = 1;
     private static final Integer ROLE_ID_DOWNLOAD = 2;
@@ -193,7 +193,7 @@ public class UserDao extends AbstractDao {
                                                    settings.getAvatarScheme().name(), settings.getSystemAvatarId(), settings.getChanged(),
                                                    settings.isShowChatEnabled(), settings.isShowArtistInfoEnabled(), settings.isAutoHidePlayQueue(),
                                                    settings.isViewAsList(), settings.getDefaultAlbumList().getId(), settings.isQueueFollowingSongs(),
-                                                   settings.isShowSideBar()});
+                                                   settings.isShowSideBar(), settings.getListReloadDelay()});
     }
 
     private static String encrypt(String s) {
@@ -354,6 +354,7 @@ public class UserDao extends AbstractDao {
             settings.setDefaultAlbumList(AlbumListType.fromId(rs.getString(col++)));
             settings.setQueueFollowingSongs(rs.getBoolean(col++));
             settings.setShowSideBar(rs.getBoolean(col++));
+            settings.setListReloadDelay((Integer) rs.getObject(col++));
 
             return settings;
         }

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/schema/hsql/Schema61.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/schema/hsql/Schema61.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Libresonic.
+ *
+ *  Libresonic is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Libresonic is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Libresonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.libresonic.player.dao.schema.hsql;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import org.libresonic.player.Logger;
+import org.libresonic.player.dao.schema.Schema;
+
+/**
+ * Used for creating and evolving the database schema.
+ * This class implements the database schema for Libresonic version 6.1.
+ *
+ * @author François-Xavier Thomas
+ */
+public class Schema61 extends Schema {
+
+    private static final Logger LOG = Logger.getLogger(Schema61.class);
+
+    @Override
+    public void execute(JdbcTemplate template) {
+
+        if (template.queryForInt("select count(*) from version where version = 26") == 0) {
+            LOG.info("Updating database schema to version 26.");
+            template.execute("insert into version values (26)");
+        }
+
+        if (!columnExists(template, "list_reload_delay", "user_settings")) {
+            LOG.info("Database column 'user_settings.list_reload_delay' not found.  Creating it.");
+            template.execute("alter table user_settings add list_reload_delay int default 60 not null");
+            LOG.info("Database column 'user_settings.list_reload_delay' was added successfully.");
+        }
+    }
+}

--- a/libresonic-main/src/main/java/org/libresonic/player/domain/UserSettings.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/domain/UserSettings.java
@@ -46,6 +46,7 @@ public class UserSettings {
     private Visibility mainVisibility = new Visibility();
     private Visibility playlistVisibility = new Visibility();
     private boolean lastFmEnabled;
+    private int listReloadDelay;
     private String lastFmUsername;
     private String lastFmPassword;
     private TranscodeScheme transcodeScheme = TranscodeScheme.OFF;
@@ -154,6 +155,14 @@ public class UserSettings {
 
     public void setLastFmEnabled(boolean lastFmEnabled) {
         this.lastFmEnabled = lastFmEnabled;
+    }
+
+    public int getListReloadDelay() {
+        return listReloadDelay;
+    }
+
+    public void setListReloadDelay(int listReloadDelay) {
+        this.listReloadDelay = listReloadDelay;
     }
 
     public String getLastFmUsername() {

--- a/libresonic-main/src/main/java/org/libresonic/player/service/SettingsService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/SettingsService.java
@@ -1270,6 +1270,7 @@ public class SettingsService {
         settings.setQueueFollowingSongs(true);
         settings.setDefaultAlbumList(AlbumListType.RANDOM);
         settings.setLastFmEnabled(false);
+        settings.setListReloadDelay(60);
         settings.setLastFmUsername(null);
         settings.setLastFmPassword(null);
         settings.setChanged(new Date());

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_en.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_en.properties
@@ -378,6 +378,7 @@ personalsettings.autohideplayqueue = Auto-hide play queue
 personalsettings.finalversionnotification = Notify me about new versions
 personalsettings.betaversionnotification = Notify me about new beta versions
 personalsettings.songnotification = Notify me when new songs are played (not supported by all browsers)
+personalsettings.listreloaddelay = Album list reload delay (in seconds, 0 disables)
 personalsettings.lastfmenabled = Register what I'm playing at <a href="http://last.fm/" target="_blank">Last.fm</a>
 personalsettings.lastfmusername = Last.fm username
 personalsettings.lastfmpassword = Last.fm password

--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
@@ -7,7 +7,9 @@
 
     <script type="text/javascript" language="javascript">
         function init() {
-            setTimeout("refresh()", 60000);
+            <c:if test="${model.listReloadDelay gt 0}">
+            setTimeout("refresh()", ${model.listReloadDelay * 1000});
+            </c:if>
 
             <c:if test="${not model.musicFoldersExist}">
             $().toastmessage("showNoticeToast", "<fmt:message key="top.missing"/>");

--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
@@ -179,6 +179,13 @@
         </tr>
     </table>
 
+    <table class="indent">
+        <tr>
+            <td><fmt:message key="personalsettings.listreloaddelay"/></td>
+            <td><form:input path="listReloadDelay" size="24"/></td>
+        </tr>
+    </table>
+
     <table id="lastFmTable" style="padding-left:2em">
         <tr>
             <td><fmt:message key="personalsettings.lastfmusername"/></td>


### PR DESCRIPTION
This PR fixes #113 and adds an user preference for changing (or disabling) the refresh delay in the home page.

![screenshot from 2016-07-19 22-51-30](https://cloud.githubusercontent.com/assets/613594/16966153/909a5f64-4e03-11e6-9c36-b5ac71ae3364.png)