### PR TITLE
Queue shuffle behavior

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/domain/PlayQueue.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/domain/PlayQueue.java
@@ -241,7 +241,8 @@ public class PlayQueue {
         MediaFile currentFile = getCurrentFile();
         Collections.shuffle(files);
         if (currentFile != null) {
-            index = files.indexOf(currentFile);
+            Collections.swap(files, files.indexOf(currentFile), 0);
+            index = 0;
         }
     }
 


### PR DESCRIPTION
I think this should fix the low-hanging fruit that is #71 : the currently-playing track is placed on top of the shuffled play queue.
