### PR TITLE
Basic CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+sudo: required
+jdk:
+  - oraclejdk8
+cache:
+  directories:
+    - $HOME/.m2
+install:
+  - sudo apt-get -qq update
+  - sudo apt-get -y install lintian fakeroot rpm python-rpm
+  - git clone https://github.com/rpm-software-management/rpmlint -o rpmlint-1.9
+  - sudo make -C rpmlint install
+script:
+  - mvn -Pfull,rpm package install
+  - mvn -Pfull -pl libresonic-assembly assembly:single

--- a/BUILD.md
+++ b/BUILD.md
@@ -8,6 +8,7 @@ Requirements
   * Recent version of [Maven](http://maven.apache.org/).
   * A JDK installation. 1.8.x series of OpenJDK or Oracle JDK 8+ should work.
   * Optional: lintian and fakeroot, for .deb package
+  * Optional: rpm and rpmlint, for .rpm package
   * Test as follows:
 
 ```
@@ -53,14 +54,39 @@ $
 Packaged .deb
 -------------
 
-You can furthermore go ahead to create a .deb suitable for installation on Debian or Ubuntu. These instructions should similarly work with rpm(for RedHat/CentOS or Fedora), but it is has not been tested.
+You can furthermore go ahead to create a .deb suitable for installation on
+Debian or Ubuntu.
 
 ```
 $ mvn -P full -pl libresonic-booter -am install
-$ mvn -P full -pl libresonic-installer-debian/ -am install
+$ mvn -P full -pl libresonic-installer-debian -am install
 $ sudo dpkg -i ./libresonic-installer-debian/target/libresonic-*.deb
-$
 ```
 
-Good luck!
+Packaged RPM
+------------
 
+Building a RPM package is very similar :
+
+```
+$ mvn -P full -pl libresonic-booter -am install
+$ mvn -P full,rpm -pl libresonic-installer-rpm -am install
+$ sudo rpm -ivh libresonic-installer-rpm/target/libresonic-*.rpm
+```
+
+Additional release archives
+---------------------------
+
+Additional release archives can be built using the following commands :
+
+```
+$ mvn -Pfull -pl libresonic-assembly assembly:single
+```
+
+These archives are built in `libresonic-assembly/targets` and include :
+
+* The source distribution
+* The standalone archive (for use without a WAR container)
+* The WAR archive (for WAR containers)
+
+Good luck!

--- a/libresonic-installer-debian/src/DEBIAN/control
+++ b/libresonic-installer-debian/src/DEBIAN/control
@@ -4,7 +4,7 @@ Section: Multimedia
 Priority: optional
 Recommends: ffmpeg
 Architecture: all
-Maintainer: Sindre Mehus <sindre@activeobjects.no>
+Maintainer: Eugene E. Kashpureff Jr <eugene@kashpureff.org>
 Description: A web-based music streamer, jukebox and Podcast receiver
  Libresonic is a web-based music streamer, jukebox and Podcast receiver,
  providing access to your music collection wherever you are. Use it

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,10 @@
                         <configuration>
                             <failOnWarning>${failOnDependencyWarning}</failOnWarning>
                             <ignoreNonCompile>true</ignoreNonCompile>
+                            <ignoredUnusedDeclaredDependencies>
+                              <ignoredUnusedDeclaredDependency>com.sun.mail:javax.mail*</ignoredUnusedDeclaredDependency>
+                              <ignoredUnusedDeclaredDependency>org.seamless:seamless-http*</ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This PR adds configuration for Travis CI (see #65) :
- [x] Build Libresonic
- [x] Generate DEB package
- [x] Generate RPM package
- [x] Generate standalone package
- [x] Generate source archive
- [x] Generate WAR package
- [x] Update build documentation

See build logs here for now, until this is merged on the main repo : https://travis-ci.org/fxthomas/libresonic.

The following items should probably be reserved to a separate pull request or issue :
- OSX support
- Windows support
- Upload generated packages to GitHub releases
