### PR TITLE
Remove unneeded dependencies.

### DIFF
--- a/libresonic-main/pom.xml
+++ b/libresonic-main/pom.xml
@@ -260,12 +260,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.5.5</version>
-        </dependency>
-
-        <dependency>
             <groupId>taglibs</groupId>
             <artifactId>standard</artifactId>
             <version>1.1.2</version>
@@ -302,12 +296,6 @@
             <groupId>org.fourthline.cling</groupId>
             <artifactId>cling-support</artifactId>
             <version>2.0.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.seamless</groupId>
-            <artifactId>seamless-http</artifactId>
-            <version>1.1.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Causing build failures with mvn -B, due to maven-dependency-plugin

Signed-off-by: Tom Powell <zifnab@zifnab06.net>