### PR TITLE
Fix overflow issue with non-square cover art images

### DIFF
--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
@@ -481,6 +481,7 @@
                     <c:param name="coverArtSize" value="${model.coverArtSizeMedium}"/>
                     <c:param name="showLink" value="true"/>
                     <c:param name="appearAfter" value="${loopStatus.count * 30}"/>
+                    <c:param name="hideOverflow" value="true"/>
                 </c:import>
             </div>
         </c:forEach>

--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/artistMain.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/artistMain.jsp
@@ -273,6 +273,7 @@
                             <c:param name="coverArtSize" value="${model.coverArtSizeMedium}"/>
                             <c:param name="showLink" value="true"/>
                             <c:param name="appearAfter" value="${loopStatus.count * 30}"/>
+                            <c:param name="hideOverflow" value="true"/>
                         </c:import>
                     </div>
                 </c:if>

--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/coverArt.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/coverArt.jsp
@@ -15,6 +15,7 @@ PARAMETERS
   showZoom: Whether to display a link for zooming the cover art.
   showChange: Whether to display a link for changing the cover art.
   appearAfter: Fade in after this many milliseconds, or nil if no fading in should happen.
+  hideOverflow: Hide cover art overflow when height is greater than width
 --%>
 <c:choose>
     <c:when test="${empty param.coverArtSize}">
@@ -32,7 +33,7 @@ PARAMETERS
 <str:randomString count="5" type="alphabet" var="playId"/>
 
 <div class="coverart dropshadow">
-    <div style="width:${size};max-width:${size};height:${size};max-height:${size};cursor:pointer" title="${param.caption1}" id="${divId}">
+    <div style="width:${size};max-width:${size};height:${size};max-height:${size};cursor:pointer;<c:if test="${param.hideOverflow}">overflow:hidden</c:if>;" title="${param.caption1}" id="${divId}">
 
         <c:if test="${not empty param.albumId}">
             <c:url value="main.view" var="targetUrl">

--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
@@ -111,6 +111,7 @@
             <c:param name="coverArtSize" value="${model.coverArtSize}"/>
             <c:param name="showLink" value="true"/>
             <c:param name="appearAfter" value="${loopStatus.count * 30}"/>
+            <c:param name="hideOverflow" value="true"/>
         </c:import>
 
         <c:if test="${not empty album.rating}">

--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/starred.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/starred.jsp
@@ -73,6 +73,7 @@
                 <c:param name="coverArtSize" value="${model.coverArtSize}"/>
                 <c:param name="showLink" value="true"/>
                 <c:param name="appearAfter" value="${loopStatus.count * 30}"/>
+                <c:param name="hideOverflow" value="true"/>
             </c:import>
         </div>
     </c:forEach>


### PR DESCRIPTION
This PR tries to prevent non-square cover art images from overflowing their container in thumbnail views. For me this happened with some quite old and odd albums from the early 90's ; it is definitely not frequent, but the UI is not very pretty or usable when it happens.

I starred a few albums to demonstrate this behavior. This is before :

![screenshot from 2016-11-12 16-28-53](https://cloud.githubusercontent.com/assets/613594/20238950/3ba050c4-a8f6-11e6-93d0-5bddabb74729.png)

...and this is after the fix :

![screenshot from 2016-11-12 16-27-35](https://cloud.githubusercontent.com/assets/613594/20238953/45e9026a-a8f6-11e6-9b0c-f450030f4987.png)