### PR TITLE
Second attempt at fixing the shuffle behavior

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/controller/StreamController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/StreamController.java
@@ -133,6 +133,15 @@ public class StreamController implements Controller {
                     return null;
                 }
 
+                // Update the index of the currently playing media file. At
+                // this point we haven't yet modified the play queue to support
+                // multiple streams, so the current play queue is the real one.
+                int currentIndex = player.getPlayQueue().getFiles().indexOf(file);
+                player.getPlayQueue().setIndex(currentIndex);
+
+                // Create a new, fake play queue that only contains the
+                // currently playing media file, in case multiple streams want
+                // to use the same player.
                 PlayQueue playQueue = new PlayQueue();
                 playQueue.addFiles(true, file);
                 player.setPlayQueue(playQueue);


### PR DESCRIPTION
This one was a bit hairier than I originally assumed : contrary to what I expected the `getCurrentFile` method never actually returned the currently playing file because... it was never updated when streaming.

This PR fixes that and the shuffle button now correctly floats the currently playing track to the top.