### PR TITLE
Fix shortcut help text and cover art overflow

### DIFF
--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/coverArt.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/coverArt.jsp
@@ -15,6 +15,7 @@ PARAMETERS
   showZoom: Whether to display a link for zooming the cover art.
   showChange: Whether to display a link for changing the cover art.
   appearAfter: Fade in after this many milliseconds, or nil if no fading in should happen.
+  hideOverflow: Hide cover art overflow when height is greater than width
 --%>
 <c:choose>
     <c:when test="${empty param.coverArtSize}">
@@ -32,7 +33,7 @@ PARAMETERS
 <str:randomString count="5" type="alphabet" var="playId"/>
 
 <div class="coverart dropshadow">
-    <div style="width:${size};max-width:${size};height:${size};max-height:${size};cursor:pointer" title="${param.caption1}" id="${divId}">
+    <div style="width:${size};max-width:${size};height:${size};max-height:${size};cursor:pointer;<c:if test="${param.hideOverflow}">overflow:hidden</c:if>;" title="${param.caption1}" id="${divId}">
 
         <c:if test="${not empty param.albumId}">
             <c:url value="main.view" var="targetUrl">

--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/more.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/more.jsp
@@ -342,7 +342,7 @@
         <td class="more-shortcut">m</td><td class="more-shortcut-descr"><fmt:message key="more.keyboard.sidebar"/></td>
     </tr>
     <tr>
-        <td class="more-shortcut">&#8593;</td><td class="more-shortcut-descr"><fmt:message key="more.keyboard.next"/></td>
+        <td class="more-shortcut">&#8594;</td><td class="more-shortcut-descr"><fmt:message key="more.keyboard.next"/></td>
         <td class="more-shortcut">g <fmt:message key="more.keyboard.then"/> o</td><td class="more-shortcut-descr"><fmt:message key="more.keyboard.podcasts"/></td>
         <td class="more-shortcut">q</td><td class="more-shortcut-descr"><fmt:message key="more.keyboard.playqueue"/></td>
     </tr>


### PR DESCRIPTION
Two very small fixes :

* A recent commit broke #139 and made large cover art images overflow again
* As a comment in #110 said, the help text for the "next song" shortcut was wrong