### PR TITLE
Use original file type for display formatting

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/PlayQueueService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/PlayQueueService.java
@@ -697,7 +697,7 @@ public class PlayQueueService {
     }
 
     private String formatFormat(Player player, MediaFile file) {
-        return transcodingService.getSuffix(player, file, null);
+        return file.getFormat();
     }
 
     private String formatContentType(String format) {


### PR DESCRIPTION
The bitrate column uses the original file, so the file type column
should do the same for consistency.

Fixes #131

Signed-off-by: David Russell <david.russell.scotland@gmail.com>