### PR TITLE
Fix #212, activate legacy datasource profile

### DIFF
--- a/libresonic-main/src/main/resources/application.properties
+++ b/libresonic-main/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.mvc.view.prefix: /WEB-INF/jsp/
 spring.mvc.view.suffix: .jsp
 server.error.includeStacktrace: ALWAYS
+spring.profiles.active: legacy


### PR DESCRIPTION
This fixed the database not saving issue in Libresonic for me (Issue #212).  It seems that the Spring wasn't pulling in the datasource profile so it wasn't actually creating a Hsqldb in-file database (must have being doing in-memory since everything worked, but /var/libresonic/db was empy).  This sets the active profile to "legacy" to enable the normal datasource (via DatasourceProfileActivatorPropertySource).  I'm not sure if this should actually be set somewhere else or if this is the completely wrong fix (maybe the embed and jndi profiles should be active as well?).  I haven't done Spring in many years so it was a bit of a struggle to figure out what was breaking and how to get my new install to actually save to disk.  This is also my first commit/pull request in git, sorry for any mistakes I am making!  