### PR TITLE
Add Spring web minimal logging config

### DIFF
--- a/libresonic-main/src/main/resources/application.properties
+++ b/libresonic-main/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.mvc.view.prefix: /WEB-INF/jsp/
 spring.mvc.view.suffix: .jsp
 server.error.includeStacktrace: ALWAYS
+logging.level.org.springframework.web=INFO


### PR DESCRIPTION
Default logging level is set to INFO.
If set to DEBUG one can see each http request being handled.