### PR TITLE
Standardize import order and add maven plugin to check

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <module name="TreeWalker">
+        <module name="CustomImportOrder">
+            <property name="customImportOrderRules"
+                      value="THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC"/>
+            <property name="specialImportsRegExp" value="^javax\."/>
+            <property name="standardPackageRegExp" value="^java\."/>
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+        </module>
+        <module name="UnusedImports"/>
+        <module name="RedundantImport"/>
+    </module>
+</module>

--- a/libresonic-main/pom.xml
+++ b/libresonic-main/pom.xml
@@ -395,6 +395,10 @@
         <finalName>libresonic</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>

--- a/libresonic-main/src/main/java/org/json/JSONObject.java
+++ b/libresonic-main/src/main/java/org/json/JSONObject.java
@@ -27,15 +27,9 @@ SOFTWARE.
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.ResourceBundle;
+import java.lang.reflect.Modifier;
+import java.util.*;
 
 /**
  * A JSONObject is an unordered collection of name/value pairs. Its

--- a/libresonic-main/src/main/java/org/json/JSONTokener.java
+++ b/libresonic-main/src/main/java/org/json/JSONTokener.java
@@ -1,11 +1,6 @@
 package org.json;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.*;
 
 /*
 Copyright (c) 2002 JSON.org

--- a/libresonic-main/src/main/java/org/libresonic/player/Logger.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/Logger.java
@@ -19,14 +19,22 @@
  */
 package org.libresonic.player;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.libresonic.player.domain.Version;
-import org.libresonic.player.service.*;
-import org.libresonic.player.util.*;
-import org.apache.commons.lang.exception.*;
+import org.libresonic.player.service.ServiceLocator;
+import org.libresonic.player.service.SettingsService;
+import org.libresonic.player.service.VersionService;
+import org.libresonic.player.util.BoundedList;
 
-import java.io.*;
-import java.text.*;
-import java.util.*;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Logger implementation which logs to LIBRESONIC_HOME/libresonic.log.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/ArtistInfo.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/ArtistInfo.java
@@ -19,9 +19,9 @@
 
 package org.libresonic.player.ajax;
 
-import java.util.List;
-
 import org.libresonic.player.domain.ArtistBio;
+
+import java.util.List;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/ChatService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/ChatService.java
@@ -19,20 +19,17 @@
  */
 package org.libresonic.player.ajax;
 
-import org.libresonic.player.Logger;
-import org.libresonic.player.service.SecurityService;
-import org.libresonic.player.util.BoundedList;
 import org.apache.commons.lang.StringUtils;
 import org.directwebremoting.WebContext;
 import org.directwebremoting.WebContextFactory;
+import org.libresonic.player.Logger;
+import org.libresonic.player.service.SecurityService;
+import org.libresonic.player.util.BoundedList;
 
 import javax.servlet.http.HttpServletRequest;
+
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/CoverArtService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/CoverArtService.java
@@ -19,19 +19,12 @@
  */
 package org.libresonic.player.ajax;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.LastFmCoverArt;
 import org.libresonic.player.domain.MediaFile;
@@ -39,6 +32,12 @@ import org.libresonic.player.service.LastFmService;
 import org.libresonic.player.service.MediaFileService;
 import org.libresonic.player.service.SecurityService;
 import org.libresonic.player.util.StringUtil;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
 
 /**
  * Provides AJAX-enabled services for changing cover art images.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/LyricsService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/LyricsService.java
@@ -19,10 +19,6 @@
  */
 package org.libresonic.player.ajax;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.net.SocketException;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
@@ -34,9 +30,12 @@ import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.util.StringUtil;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.SocketException;
 
 /**
  * Provides AJAX-enabled services for retrieving song lyrics from chartlyrics.com.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/MultiService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/MultiService.java
@@ -19,25 +19,20 @@
  */
 package org.libresonic.player.ajax;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.directwebremoting.WebContextFactory;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.ArtistBio;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.MusicFolder;
 import org.libresonic.player.domain.UserSettings;
-import org.libresonic.player.service.LastFmService;
-import org.libresonic.player.service.MediaFileService;
-import org.libresonic.player.service.NetworkService;
-import org.libresonic.player.service.SecurityService;
-import org.libresonic.player.service.SettingsService;
+import org.libresonic.player.service.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Provides miscellaneous AJAX-enabled services.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/NowPlayingService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/NowPlayingService.java
@@ -19,28 +19,22 @@
  */
 package org.libresonic.player.ajax;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.commons.lang.StringUtils;
 import org.directwebremoting.WebContext;
 import org.directwebremoting.WebContextFactory;
-
 import org.libresonic.player.Logger;
-import org.libresonic.player.domain.AvatarScheme;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.PlayStatus;
-import org.libresonic.player.domain.Player;
-import org.libresonic.player.domain.UserSettings;
+import org.libresonic.player.domain.*;
 import org.libresonic.player.service.MediaScannerService;
 import org.libresonic.player.service.PlayerService;
 import org.libresonic.player.service.SettingsService;
 import org.libresonic.player.service.StatusService;
 import org.libresonic.player.util.StringUtil;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Provides AJAX-enabled services for retrieving the currently playing file and directory.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/PlayQueueInfo.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/PlayQueueInfo.java
@@ -19,9 +19,9 @@
  */
 package org.libresonic.player.ajax;
 
-import java.util.List;
-
 import org.libresonic.player.util.StringUtil;
+
+import java.util.List;
 
 /**
  * The playlist of a player.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/PlayQueueService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/PlayQueueService.java
@@ -19,46 +19,21 @@
  */
 package org.libresonic.player.ajax;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import org.directwebremoting.WebContextFactory;
+import org.libresonic.player.dao.MediaFileDao;
+import org.libresonic.player.dao.PlayQueueDao;
+import org.libresonic.player.domain.*;
+import org.libresonic.player.service.*;
+import org.libresonic.player.service.PlaylistService;
+import org.libresonic.player.util.StringUtil;
+import org.springframework.web.servlet.support.RequestContextUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.directwebremoting.WebContextFactory;
-import org.springframework.web.servlet.support.RequestContextUtils;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
-import org.libresonic.player.dao.MediaFileDao;
-import org.libresonic.player.dao.PlayQueueDao;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.MusicFolder;
-import org.libresonic.player.domain.PlayQueue;
-import org.libresonic.player.domain.Player;
-import org.libresonic.player.domain.PodcastEpisode;
-import org.libresonic.player.domain.PodcastStatus;
-import org.libresonic.player.domain.SavedPlayQueue;
-import org.libresonic.player.domain.UrlRedirectType;
-import org.libresonic.player.domain.UserSettings;
-import org.libresonic.player.service.JukeboxService;
-import org.libresonic.player.service.LastFmService;
-import org.libresonic.player.service.MediaFileService;
-import org.libresonic.player.service.PlayerService;
-import org.libresonic.player.service.PlaylistService;
-import org.libresonic.player.service.PodcastService;
-import org.libresonic.player.service.RatingService;
-import org.libresonic.player.service.SearchService;
-import org.libresonic.player.service.SecurityService;
-import org.libresonic.player.service.SettingsService;
-import org.libresonic.player.service.TranscodingService;
-import org.libresonic.player.util.StringUtil;
+import java.util.*;
 
 /**
  * Provides AJAX-enabled services for manipulating the play queue of a player.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/PlaylistInfo.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/PlaylistInfo.java
@@ -19,10 +19,9 @@
  */
 package org.libresonic.player.ajax;
 
-import java.util.List;
-
-import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.Playlist;
+
+import java.util.List;
 
 /**
  * The playlist of a player.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/PlaylistService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/PlaylistService.java
@@ -19,6 +19,7 @@
  */
 package org.libresonic.player.ajax;
 
+import org.directwebremoting.WebContextFactory;
 import org.libresonic.player.dao.MediaFileDao;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.MusicFolder;
@@ -29,17 +30,12 @@ import org.libresonic.player.service.MediaFileService;
 import org.libresonic.player.service.PlayerService;
 import org.libresonic.player.service.SecurityService;
 import org.libresonic.player.service.SettingsService;
-import org.directwebremoting.WebContextFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.text.DateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.ResourceBundle;
+import java.util.*;
 
 /**
  * Provides AJAX-enabled services for manipulating playlists.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/StarService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/StarService.java
@@ -19,12 +19,12 @@
  */
 package org.libresonic.player.ajax;
 
+import org.directwebremoting.WebContext;
+import org.directwebremoting.WebContextFactory;
 import org.libresonic.player.Logger;
 import org.libresonic.player.dao.MediaFileDao;
 import org.libresonic.player.domain.User;
 import org.libresonic.player.service.SecurityService;
-import org.directwebremoting.WebContext;
-import org.directwebremoting.WebContextFactory;
 
 /**
  * Provides AJAX-enabled services for starring.

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/TagService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/TagService.java
@@ -22,7 +22,6 @@ package org.libresonic.player.ajax;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.service.MediaFileService;

--- a/libresonic-main/src/main/java/org/libresonic/player/ajax/TransferService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/ajax/TransferService.java
@@ -19,11 +19,11 @@
  */
 package org.libresonic.player.ajax;
 
-import org.libresonic.player.domain.*;
-import org.libresonic.player.controller.*;
-import org.directwebremoting.*;
+import org.directwebremoting.WebContextFactory;
+import org.libresonic.player.controller.UploadController;
+import org.libresonic.player.domain.TransferStatus;
 
-import javax.servlet.http.*;
+import javax.servlet.http.HttpSession;
 
 /**
  * Provides AJAX-enabled services for retrieving the status of ongoing transfers.

--- a/libresonic-main/src/main/java/org/libresonic/player/cache/CacheFactory.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/cache/CacheFactory.java
@@ -19,18 +19,15 @@
  */
 package org.libresonic.player.cache;
 
-
-import java.io.File;
-
-import org.springframework.beans.factory.InitializingBean;
-
-import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.config.Configuration;
 import net.sf.ehcache.config.ConfigurationFactory;
 import org.libresonic.player.Logger;
 import org.libresonic.player.service.SettingsService;
+import org.springframework.beans.factory.InitializingBean;
+
+import java.io.File;
 
 /**
  * Initializes Ehcache and creates caches.

--- a/libresonic-main/src/main/java/org/libresonic/player/command/MusicFolderSettingsCommand.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/command/MusicFolderSettingsCommand.java
@@ -19,13 +19,13 @@
  */
 package org.libresonic.player.command;
 
+import org.apache.commons.lang.StringUtils;
+import org.libresonic.player.controller.MusicFolderSettingsController;
+import org.libresonic.player.domain.MusicFolder;
+
 import java.io.File;
 import java.util.Date;
 import java.util.List;
-
-import org.libresonic.player.controller.MusicFolderSettingsController;
-import org.libresonic.player.domain.MusicFolder;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Command used in {@link MusicFolderSettingsController}.

--- a/libresonic-main/src/main/java/org/libresonic/player/command/PasswordSettingsCommand.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/command/PasswordSettingsCommand.java
@@ -19,7 +19,7 @@
  */
 package org.libresonic.player.command;
 
-import org.libresonic.player.controller.*;
+import org.libresonic.player.controller.PasswordSettingsController;
 
 /**
  * Command used in {@link PasswordSettingsController}.

--- a/libresonic-main/src/main/java/org/libresonic/player/command/PersonalSettingsCommand.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/command/PersonalSettingsCommand.java
@@ -19,14 +19,10 @@
  */
 package org.libresonic.player.command;
 
-import java.util.List;
-
 import org.libresonic.player.controller.PersonalSettingsController;
-import org.libresonic.player.domain.AlbumListType;
-import org.libresonic.player.domain.Avatar;
-import org.libresonic.player.domain.Theme;
-import org.libresonic.player.domain.User;
-import org.libresonic.player.domain.UserSettings;
+import org.libresonic.player.domain.*;
+
+import java.util.List;
 
 /**
  * Command used in {@link PersonalSettingsController}.

--- a/libresonic-main/src/main/java/org/libresonic/player/command/PlayerSettingsCommand.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/command/PlayerSettingsCommand.java
@@ -19,14 +19,14 @@
  */
 package org.libresonic.player.command;
 
-import java.util.Date;
-import java.util.List;
-
 import org.libresonic.player.controller.PlayerSettingsController;
 import org.libresonic.player.domain.Player;
 import org.libresonic.player.domain.PlayerTechnology;
 import org.libresonic.player.domain.TranscodeScheme;
 import org.libresonic.player.domain.Transcoding;
+
+import java.util.Date;
+import java.util.List;
 
 /**
  * Command used in {@link PlayerSettingsController}.

--- a/libresonic-main/src/main/java/org/libresonic/player/command/SearchCommand.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/command/SearchCommand.java
@@ -19,10 +19,12 @@
  */
 package org.libresonic.player.command;
 
-import org.libresonic.player.domain.*;
-import org.libresonic.player.controller.*;
+import org.libresonic.player.controller.SearchController;
+import org.libresonic.player.domain.MediaFile;
+import org.libresonic.player.domain.Player;
+import org.libresonic.player.domain.User;
 
-import java.util.*;
+import java.util.List;
 
 /**
  * Command used in {@link SearchController}.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/AbstractChartController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/AbstractChartController.java
@@ -19,13 +19,13 @@
  */
 package org.libresonic.player.controller;
 
-import org.springframework.web.servlet.support.*;
-import org.springframework.web.servlet.mvc.*;
-import org.springframework.ui.context.*;
+import org.springframework.ui.context.Theme;
+import org.springframework.web.servlet.support.RequestContextUtils;
 
-import javax.servlet.http.*;
+import javax.servlet.http.HttpServletRequest;
+
 import java.awt.*;
-import java.util.*;
+import java.util.Locale;
 
 /**
  * Abstract super class for controllers which generate charts.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/AdvancedSettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/AdvancedSettingsController.java
@@ -25,11 +25,9 @@ import org.libresonic.player.service.SettingsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/AllmusicController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/AllmusicController.java
@@ -19,13 +19,13 @@
  */
 package org.libresonic.player.controller;
 
-
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.http.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Controller for the page which forwards to allmusic.com.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/AutoCoverDemo.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/AutoCoverDemo.java
@@ -19,17 +19,12 @@
  */
 package org.libresonic.player.controller;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.io.IOException;
-
-import javax.swing.JComponent;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-
 import org.apache.commons.lang.RandomStringUtils;
+
+import javax.swing.*;
+
+import java.awt.*;
+import java.io.IOException;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/AvatarController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/AvatarController.java
@@ -19,9 +19,10 @@
  */
 package org.libresonic.player.controller;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import org.libresonic.player.domain.Avatar;
+import org.libresonic.player.domain.AvatarScheme;
+import org.libresonic.player.domain.UserSettings;
+import org.libresonic.player.service.SettingsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.ServletRequestUtils;
@@ -30,10 +31,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.LastModified;
 
-import org.libresonic.player.domain.Avatar;
-import org.libresonic.player.domain.AvatarScheme;
-import org.libresonic.player.domain.UserSettings;
-import org.libresonic.player.service.SettingsService;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Controller which produces avatar images.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/AvatarUploadController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/AvatarUploadController.java
@@ -19,27 +19,27 @@
  */
 package org.libresonic.player.controller;
 
-import org.libresonic.player.Logger;
-import org.libresonic.player.domain.Avatar;
-import org.libresonic.player.service.SecurityService;
-import org.libresonic.player.service.SettingsService;
-import org.libresonic.player.util.StringUtil;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
+import org.libresonic.player.Logger;
+import org.libresonic.player.domain.Avatar;
+import org.libresonic.player.service.SecurityService;
+import org.libresonic.player.service.SettingsService;
+import org.libresonic.player.util.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.ParameterizableViewController;
 
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/ChangeCoverArtController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/ChangeCoverArtController.java
@@ -31,6 +31,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/CoverArtController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/CoverArtController.java
@@ -41,6 +41,7 @@ import javax.annotation.PostConstruct;
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.*;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/DBController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/DBController.java
@@ -31,6 +31,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/DLNASettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/DLNASettingsController.java
@@ -18,22 +18,21 @@
  */
 package org.libresonic.player.controller;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.commons.lang.StringUtils;
+import org.libresonic.player.service.SettingsService;
+import org.libresonic.player.service.UPnPService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-
-import org.libresonic.player.service.SettingsService;
-import org.libresonic.player.service.UPnPService;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Controller for the page used to administrate the UPnP/DLNA server settings.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/DownloadController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/DownloadController.java
@@ -19,25 +19,15 @@
  */
 package org.libresonic.player.controller;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.zip.CRC32;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.libresonic.player.Logger;
+import org.libresonic.player.domain.*;
+import org.libresonic.player.io.RangeOutputStream;
+import org.libresonic.player.service.*;
+import org.libresonic.player.util.FileUtil;
+import org.libresonic.player.util.HttpRange;
+import org.libresonic.player.util.Util;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.ServletRequestBindingException;
@@ -47,23 +37,16 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.LastModified;
 
-import org.libresonic.player.Logger;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.PlayQueue;
-import org.libresonic.player.domain.Player;
-import org.libresonic.player.domain.Playlist;
-import org.libresonic.player.domain.TransferStatus;
-import org.libresonic.player.domain.User;
-import org.libresonic.player.io.RangeOutputStream;
-import org.libresonic.player.service.MediaFileService;
-import org.libresonic.player.service.PlayerService;
-import org.libresonic.player.service.PlaylistService;
-import org.libresonic.player.service.SecurityService;
-import org.libresonic.player.service.SettingsService;
-import org.libresonic.player.service.StatusService;
-import org.libresonic.player.util.FileUtil;
-import org.libresonic.player.util.HttpRange;
-import org.libresonic.player.util.Util;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  * A controller used for downloading files to a remote client. If the requested path refers to a file, the

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/EditTagsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/EditTagsController.java
@@ -34,6 +34,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/ExternalPlayerController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/ExternalPlayerController.java
@@ -35,6 +35,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.*;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/GettingStartedController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/GettingStartedController.java
@@ -19,10 +19,6 @@
  */
 package org.libresonic.player.controller;
 
-import org.libresonic.player.domain.AvatarScheme;
-import org.libresonic.player.domain.User;
-import org.libresonic.player.domain.UserSettings;
-import org.libresonic.player.service.SecurityService;
 import org.libresonic.player.service.SettingsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -32,7 +28,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/HLSController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/HLSController.java
@@ -19,24 +19,7 @@
  */
 package org.libresonic.player.controller;
 
-import java.awt.Dimension;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.ServletRequestUtils;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.servlet.ModelAndView;
-
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.Player;
 import org.libresonic.player.service.MediaFileService;
@@ -44,6 +27,22 @@ import org.libresonic.player.service.PlayerService;
 import org.libresonic.player.service.SecurityService;
 import org.libresonic.player.util.Pair;
 import org.libresonic.player.util.StringUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.ServletRequestUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.awt.*;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Controller which produces the HLS (Http Live Streaming) playlist.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/HelpController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/HelpController.java
@@ -19,23 +19,21 @@
  */
 package org.libresonic.player.controller;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import org.libresonic.player.Logger;
+import org.libresonic.player.service.SecurityService;
+import org.libresonic.player.service.SettingsService;
+import org.libresonic.player.service.VersionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.ParameterizableViewController;
 
-import org.libresonic.player.Logger;
-import org.libresonic.player.service.SecurityService;
-import org.libresonic.player.service.SettingsService;
-import org.libresonic.player.service.VersionService;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Controller for the help page.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/HomeController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/HomeController.java
@@ -29,6 +29,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
+
 import java.io.IOException;
 import java.util.*;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/ImportPlaylistController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/ImportPlaylistController.java
@@ -19,29 +19,27 @@
  */
 package org.libresonic.player.controller;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
+import org.libresonic.player.domain.Playlist;
+import org.libresonic.player.service.PlaylistService;
+import org.libresonic.player.service.SecurityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.ParameterizableViewController;
 
-import org.libresonic.player.domain.Playlist;
-import org.libresonic.player.service.PlaylistService;
-import org.libresonic.player.service.SecurityService;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/IndexController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/IndexController.java
@@ -1,21 +1,17 @@
 package org.libresonic.player.controller;
 
 import org.libresonic.player.Logger;
-import org.libresonic.player.domain.User;
 import org.libresonic.player.domain.UserSettings;
 import org.libresonic.player.service.SecurityService;
 import org.libresonic.player.service.SettingsService;
-import org.libresonic.player.util.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/InternetRadioSettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/InternetRadioSettingsController.java
@@ -19,20 +19,17 @@
  */
 package org.libresonic.player.controller;
 
+import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.domain.InternetRadio;
 import org.libresonic.player.service.SettingsService;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.ParameterizableViewController;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.Date;
 import java.util.HashMap;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/JAXBWriter.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/JAXBWriter.java
@@ -19,10 +19,18 @@
  */
 package org.libresonic.player.controller;
 
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.persistence.jaxb.JAXBContext;
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+import org.jdom.Attribute;
+import org.jdom.Document;
+import org.jdom.input.SAXBuilder;
+import org.libresonic.player.Logger;
+import org.libresonic.player.util.StringUtil;
+import org.libresonic.restapi.Error;
+import org.libresonic.restapi.ObjectFactory;
+import org.libresonic.restapi.Response;
+import org.libresonic.restapi.ResponseStatus;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -31,19 +39,10 @@ import javax.xml.bind.Marshaller;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.apache.commons.io.IOUtils;
-import org.eclipse.persistence.jaxb.JAXBContext;
-import org.eclipse.persistence.jaxb.MarshallerProperties;
-import org.jdom.Attribute;
-import org.jdom.Document;
-import org.jdom.input.SAXBuilder;
-import org.libresonic.restapi.Error;
-import org.libresonic.restapi.ObjectFactory;
-import org.libresonic.restapi.Response;
-import org.libresonic.restapi.ResponseStatus;
-
-import org.libresonic.player.Logger;
-import org.libresonic.player.util.StringUtil;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.GregorianCalendar;
 
 import static org.springframework.web.bind.ServletRequestUtils.getStringParameter;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/LeftController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/LeftController.java
@@ -33,6 +33,7 @@ import org.springframework.web.servlet.support.RequestContextUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.File;
 import java.util.*;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/LoginController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/LoginController.java
@@ -6,10 +6,7 @@ import org.libresonic.player.service.SecurityService;
 import org.libresonic.player.service.SettingsService;
 import org.libresonic.player.util.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -18,6 +15,7 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/LyricsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/LyricsController.java
@@ -22,13 +22,13 @@ package org.libresonic.player.controller;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Map;
+
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Controller for the lyrics popup.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/M3UController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/M3UController.java
@@ -34,6 +34,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/MainController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/MainController.java
@@ -31,6 +31,7 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/MoreController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/MoreController.java
@@ -35,6 +35,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.File;
 import java.util.Calendar;
 import java.util.HashMap;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/NowPlayingController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/NowPlayingController.java
@@ -34,6 +34,7 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.List;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/PersonalSettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/PersonalSettingsController.java
@@ -30,9 +30,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.servlet.http.HttpServletRequest;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.Date;
 import java.util.Locale;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/PlayQueueController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/PlayQueueController.java
@@ -33,6 +33,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/PlayerSettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/PlayerSettingsController.java
@@ -31,9 +31,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.servlet.http.HttpServletRequest;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/PlaylistController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/PlaylistController.java
@@ -33,11 +33,11 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/PlaylistsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/PlaylistsController.java
@@ -18,31 +18,21 @@
  */
 package org.libresonic.player.controller;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import org.libresonic.player.domain.Playlist;
+import org.libresonic.player.domain.User;
+import org.libresonic.player.service.PlaylistService;
+import org.libresonic.player.service.SecurityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.ParameterizableViewController;
-import org.springframework.web.servlet.view.RedirectView;
 
-import org.libresonic.player.domain.Player;
-import org.libresonic.player.domain.Playlist;
-import org.libresonic.player.domain.User;
-import org.libresonic.player.domain.UserSettings;
-import org.libresonic.player.service.PlayerService;
-import org.libresonic.player.service.PlaylistService;
-import org.libresonic.player.service.SecurityService;
-import org.libresonic.player.service.SettingsService;
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Controller for the playlists page.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/PodcastChannelController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/PodcastChannelController.java
@@ -30,6 +30,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/PodcastChannelsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/PodcastChannelsController.java
@@ -31,6 +31,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/PodcastController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/PodcastController.java
@@ -33,6 +33,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/ProxyController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/ProxyController.java
@@ -34,6 +34,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.InputStream;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/RESTController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/RESTController.java
@@ -57,6 +57,7 @@ import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/RandomPlayQueueController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/RandomPlayQueueController.java
@@ -19,14 +19,12 @@
  */
 package org.libresonic.player.controller;
 
-import java.util.*;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.domain.*;
-import org.libresonic.player.service.*;
+import org.libresonic.player.service.MediaFileService;
+import org.libresonic.player.service.PlayerService;
+import org.libresonic.player.service.SecurityService;
+import org.libresonic.player.service.SettingsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -35,6 +33,11 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.*;
 
 /**
  * Controller for the creating a random play queue.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/RecoverController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/RecoverController.java
@@ -22,6 +22,7 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/RightController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/RightController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/SearchController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/SearchController.java
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.List;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/SettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/SettingsController.java
@@ -23,15 +23,12 @@ import org.libresonic.player.domain.User;
 import org.libresonic.player.service.SecurityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.AbstractController;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * Controller for the main settings page.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/ShareManagementController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/ShareManagementController.java
@@ -34,6 +34,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.*;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/ShareSettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/ShareSettingsController.java
@@ -19,7 +19,6 @@
  */
 package org.libresonic.player.controller;
 
-import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.MusicFolder;
@@ -37,12 +36,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.*;
 
 /**
  * Controller for the page used to administrate the set of shared media.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/SonosSettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/SonosSettingsController.java
@@ -18,7 +18,6 @@
  */
 package org.libresonic.player.controller;
 
-import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.service.SettingsService;
 import org.libresonic.player.service.SonosService;
@@ -29,6 +28,8 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import javax.servlet.http.HttpServletRequest;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/StarredController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/StarredController.java
@@ -33,6 +33,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/StatusChartController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/StatusChartController.java
@@ -19,23 +19,29 @@
  */
 package org.libresonic.player.controller;
 
-import org.libresonic.player.domain.*;
-import org.libresonic.player.service.*;
-import org.jfree.chart.*;
-import org.jfree.chart.axis.*;
-import org.jfree.chart.plot.*;
-import org.jfree.chart.renderer.xy.*;
-import org.jfree.data.*;
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.AxisLocation;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.XYItemRenderer;
+import org.jfree.data.Range;
 import org.jfree.data.time.*;
+import org.libresonic.player.domain.TransferStatus;
+import org.libresonic.player.service.StatusService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.servlet.*;
+import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.http.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.awt.*;
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/StatusController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/StatusController.java
@@ -33,6 +33,7 @@ import org.springframework.web.servlet.support.RequestContextUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.*;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/StreamController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/StreamController.java
@@ -19,17 +19,17 @@
  */
 package org.libresonic.player.controller;
 
-import java.awt.Dimension;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.io.IOUtils;
+import org.libresonic.player.Logger;
+import org.libresonic.player.domain.*;
+import org.libresonic.player.io.PlayQueueInputStream;
+import org.libresonic.player.io.RangeOutputStream;
+import org.libresonic.player.io.ShoutCastOutputStream;
+import org.libresonic.player.service.*;
+import org.libresonic.player.service.sonos.SonosHelper;
+import org.libresonic.player.util.HttpRange;
+import org.libresonic.player.util.StringUtil;
+import org.libresonic.player.util.Util;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.ServletRequestBindingException;
@@ -38,29 +38,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
-import org.libresonic.player.Logger;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.PlayQueue;
-import org.libresonic.player.domain.Player;
-import org.libresonic.player.domain.TransferStatus;
-import org.libresonic.player.domain.User;
-import org.libresonic.player.domain.VideoTranscodingSettings;
-import org.libresonic.player.io.PlayQueueInputStream;
-import org.libresonic.player.io.RangeOutputStream;
-import org.libresonic.player.io.ShoutCastOutputStream;
-import org.libresonic.player.service.AudioScrobblerService;
-import org.libresonic.player.service.MediaFileService;
-import org.libresonic.player.service.PlayerService;
-import org.libresonic.player.service.PlaylistService;
-import org.libresonic.player.service.SearchService;
-import org.libresonic.player.service.SecurityService;
-import org.libresonic.player.service.SettingsService;
-import org.libresonic.player.service.StatusService;
-import org.libresonic.player.service.TranscodingService;
-import org.libresonic.player.service.sonos.SonosHelper;
-import org.libresonic.player.util.HttpRange;
-import org.libresonic.player.util.StringUtil;
-import org.libresonic.player.util.Util;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.awt.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A controller which streams the content of a {@link org.libresonic.player.domain.PlayQueue} to a remote

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/TopController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/TopController.java
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/TranscodingSettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/TranscodingSettingsController.java
@@ -19,20 +19,18 @@
  */
 package org.libresonic.player.controller;
 
-import org.libresonic.player.domain.Transcoding;
-import org.libresonic.player.service.TranscodingService;
-import org.libresonic.player.service.SettingsService;
 import org.apache.commons.lang.StringUtils;
+import org.libresonic.player.domain.Transcoding;
+import org.libresonic.player.service.SettingsService;
+import org.libresonic.player.service.TranscodingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/UploadController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/UploadController.java
@@ -42,6 +42,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/UserChartController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/UserChartController.java
@@ -19,14 +19,6 @@
  */
 package org.libresonic.player.controller;
 
-import java.awt.Color;
-import java.awt.GradientPaint;
-import java.awt.Paint;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartUtilities;
 import org.jfree.chart.JFreeChart;
@@ -39,14 +31,19 @@ import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.renderer.category.BarRenderer;
 import org.jfree.data.category.CategoryDataset;
 import org.jfree.data.category.DefaultCategoryDataset;
+import org.libresonic.player.domain.User;
+import org.libresonic.player.service.SecurityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
-import org.libresonic.player.domain.User;
-import org.libresonic.player.service.SecurityService;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.awt.*;
+import java.util.List;
 
 /**
  * Controller for generating a chart showing bitrate vs time.

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/UserSettingsController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/UserSettingsController.java
@@ -38,10 +38,13 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.bind.WebDataBinder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.servlet.http.HttpServletRequest;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.ArrayList;
 import java.util.Date;

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/VideoPlayerController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/VideoPlayerController.java
@@ -35,6 +35,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/AbstractDao.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/AbstractDao.java
@@ -19,23 +19,15 @@
  */
 package org.libresonic.player.dao;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import org.libresonic.player.Logger;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import org.springframework.dao.DataAccessException;
-import org.springframework.jdbc.core.*;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-
-import org.libresonic.player.Logger;
-import org.springframework.jdbc.support.JdbcUtils;
-import org.springframework.jdbc.support.KeyHolder;
-import org.springframework.util.Assert;
 
 /**
  * Abstract superclass for all DAO's.

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/ArtistDao.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/ArtistDao.java
@@ -22,17 +22,12 @@ package org.libresonic.player.dao;
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.Artist;
 import org.libresonic.player.domain.MusicFolder;
-
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Provides database services for artists.

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/DaoHelper.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/DaoHelper.java
@@ -19,9 +19,10 @@
  */
 package org.libresonic.player.dao;
 
-import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import javax.sql.DataSource;
 
 /**
  * DAO helper class which creates the data source, and updates the database schema.

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/GenericDaoHelper.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/GenericDaoHelper.java
@@ -1,8 +1,9 @@
 package org.libresonic.player.dao;
 
-import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import javax.sql.DataSource;
 
 public class GenericDaoHelper implements DaoHelper {
 

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/InternetRadioDao.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/InternetRadioDao.java
@@ -19,14 +19,13 @@
  */
 package org.libresonic.player.dao;
 
+import org.libresonic.player.Logger;
+import org.libresonic.player.domain.InternetRadio;
 import org.springframework.jdbc.core.RowMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
-
-import org.libresonic.player.Logger;
-import org.libresonic.player.domain.InternetRadio;
 
 /**
  * Provides database services for internet radio.

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/MediaFileDao.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/MediaFileDao.java
@@ -20,12 +20,11 @@
 package org.libresonic.player.dao;
 
 import org.apache.commons.lang.StringUtils;
-import org.libresonic.player.domain.RandomSearchCriteria;
-import org.springframework.jdbc.core.RowMapper;
-
 import org.libresonic.player.domain.Genre;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.MusicFolder;
+import org.libresonic.player.domain.RandomSearchCriteria;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/PlaylistDao.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/PlaylistDao.java
@@ -27,11 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * Provides database services for playlists.

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/RatingDao.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/RatingDao.java
@@ -19,16 +19,14 @@
  */
 package org.libresonic.player.dao;
 
-import java.util.ArrayList;
+import org.libresonic.player.domain.MediaFile;
+import org.libresonic.player.domain.MusicFolder;
+import org.springframework.dao.EmptyResultDataAccessException;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.springframework.dao.EmptyResultDataAccessException;
-
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.MusicFolder;
 
 import static org.libresonic.player.domain.MediaFile.MediaType.ALBUM;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/domain/MediaFile.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/domain/MediaFile.java
@@ -19,16 +19,14 @@
  */
 package org.libresonic.player.domain;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import org.apache.commons.io.FilenameUtils;
+import org.libresonic.player.util.FileUtil;
+
 import java.io.File;
 import java.util.Date;
 import java.util.List;
-
-import org.apache.commons.io.FilenameUtils;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
-import org.libresonic.player.util.FileUtil;
 
 /**
  * A media file (audio, video or directory) with an assortment of its meta data.

--- a/libresonic-main/src/main/java/org/libresonic/player/domain/MusicFolder.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/domain/MusicFolder.java
@@ -19,14 +19,14 @@
  */
 package org.libresonic.player.domain;
 
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.collect.Lists;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
-
-import com.google.common.base.Function;
-import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
 
 /**
  * Represents a top level directory in which music or other media is stored.

--- a/libresonic-main/src/main/java/org/libresonic/player/domain/PlayQueue.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/domain/PlayQueue.java
@@ -19,14 +19,10 @@
  */
 package org.libresonic.player.domain;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-
 import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
+import java.util.*;
 
 /**
  * A play queue is a list of music files that are associated to a remote player.

--- a/libresonic-main/src/main/java/org/libresonic/player/domain/PodcastEpisode.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/domain/PodcastEpisode.java
@@ -21,8 +21,6 @@ package org.libresonic.player.domain;
 
 import java.util.Date;
 
-import org.libresonic.player.util.StringUtil;
-
 /**
  * A Podcast episode belonging to a channel.
  *

--- a/libresonic-main/src/main/java/org/libresonic/player/domain/SearchResult.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/domain/SearchResult.java
@@ -19,11 +19,10 @@
  */
 package org.libresonic.player.domain;
 
+import org.libresonic.player.service.SearchService;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.libresonic.player.service.MediaScannerService;
-import org.libresonic.player.service.SearchService;
 
 /**
  * The outcome of a search.

--- a/libresonic-main/src/main/java/org/libresonic/player/domain/TransferStatus.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/domain/TransferStatus.java
@@ -19,9 +19,9 @@
  */
 package org.libresonic.player.domain;
 
-import java.io.File;
-
 import org.libresonic.player.util.BoundedList;
+
+import java.io.File;
 
 /**
  * Status for a single transfer (stream, download or upload).

--- a/libresonic-main/src/main/java/org/libresonic/player/filter/BootstrapVerificationFilter.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/filter/BootstrapVerificationFilter.java
@@ -22,13 +22,7 @@ package org.libresonic.player.filter;
 import org.libresonic.player.Logger;
 import org.libresonic.player.service.SettingsService;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 
 import java.io.File;

--- a/libresonic-main/src/main/java/org/libresonic/player/filter/ParameterDecodingFilter.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/filter/ParameterDecodingFilter.java
@@ -25,6 +25,7 @@ import org.libresonic.player.util.StringUtil;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
+
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.HashMap;

--- a/libresonic-main/src/main/java/org/libresonic/player/filter/RESTFilter.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/filter/RESTFilter.java
@@ -19,23 +19,17 @@
  */
 package org.libresonic.player.filter;
 
-import java.io.IOException;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.springframework.web.bind.ServletRequestBindingException;
-import org.springframework.web.util.NestedServletException;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.controller.JAXBWriter;
 import org.libresonic.player.controller.RESTController;
+import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.web.util.NestedServletException;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
 
 import static org.libresonic.player.controller.RESTController.ErrorCode.GENERIC;
 import static org.libresonic.player.controller.RESTController.ErrorCode.MISSING_PARAMETER;

--- a/libresonic-main/src/main/java/org/libresonic/player/filter/RequestEncodingFilter.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/filter/RequestEncodingFilter.java
@@ -20,8 +20,9 @@
 package org.libresonic.player.filter;
 
 import javax.servlet.*;
-import javax.servlet.http.*;
-import java.io.*;
+import javax.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
 
 /**
  * Configurable filter for setting the character encoding to use for the HTTP request.

--- a/libresonic-main/src/main/java/org/libresonic/player/filter/ResponseHeaderFilter.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/filter/ResponseHeaderFilter.java
@@ -20,9 +20,10 @@
 package org.libresonic.player.filter;
 
 import javax.servlet.*;
-import javax.servlet.http.*;
-import java.io.*;
-import java.util.*;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Enumeration;
 
 /**
  * Configurable filter for setting HTTP response headers. Can be used, for instance, to

--- a/libresonic-main/src/main/java/org/libresonic/player/i18n/LibresonicLocaleResolver.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/i18n/LibresonicLocaleResolver.java
@@ -19,12 +19,18 @@
  */
 package org.libresonic.player.i18n;
 
-import org.libresonic.player.service.*;
-import org.libresonic.player.domain.*;
-import org.springframework.web.servlet.*;
+import org.libresonic.player.domain.UserSettings;
+import org.libresonic.player.service.SecurityService;
+import org.libresonic.player.service.SettingsService;
+import org.springframework.web.servlet.LocaleResolver;
 
-import javax.servlet.http.*;
-import java.util.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * Locale resolver implementation which returns the locale selected in the settings.

--- a/libresonic-main/src/main/java/org/libresonic/player/io/InputStreamReaderThread.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/io/InputStreamReaderThread.java
@@ -19,10 +19,13 @@
  */
 package org.libresonic.player.io;
 
-import org.libresonic.player.*;
-import org.apache.commons.io.*;
+import org.apache.commons.io.IOUtils;
+import org.libresonic.player.Logger;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 /**
  * Utility class which reads everything from an input stream and optionally logs it.

--- a/libresonic-main/src/main/java/org/libresonic/player/io/PlayQueueInputStream.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/io/PlayQueueInputStream.java
@@ -19,22 +19,18 @@
  */
 package org.libresonic.player.io;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-
 import org.libresonic.player.Logger;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.PlayQueue;
-import org.libresonic.player.domain.Player;
-import org.libresonic.player.domain.TransferStatus;
-import org.libresonic.player.domain.VideoTranscodingSettings;
+import org.libresonic.player.domain.*;
 import org.libresonic.player.service.AudioScrobblerService;
 import org.libresonic.player.service.MediaFileService;
 import org.libresonic.player.service.SearchService;
 import org.libresonic.player.service.TranscodingService;
 import org.libresonic.player.service.sonos.SonosHelper;
 import org.libresonic.player.util.FileUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Implementation of {@link InputStream} which reads from a {@link org.libresonic.player.domain.PlayQueue}.

--- a/libresonic-main/src/main/java/org/libresonic/player/io/ShoutCastOutputStream.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/io/ShoutCastOutputStream.java
@@ -19,11 +19,11 @@
  */
 package org.libresonic.player.io;
 
+import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.PlayQueue;
 import org.libresonic.player.service.SettingsService;
-import org.apache.commons.lang.StringUtils;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/libresonic-main/src/main/java/org/libresonic/player/io/TranscodeInputStream.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/io/TranscodeInputStream.java
@@ -19,11 +19,13 @@
  */
 package org.libresonic.player.io;
 
-import org.libresonic.player.*;
+import org.apache.commons.io.IOUtils;
+import org.libresonic.player.Logger;
 
-import org.apache.commons.io.*;
-
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Subclass of {@link InputStream} which provides on-the-fly transcoding.

--- a/libresonic-main/src/main/java/org/libresonic/player/security/CsrfSecurityRequestMatcher.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/security/CsrfSecurityRequestMatcher.java
@@ -5,6 +5,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
+
 import java.util.regex.Pattern;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/security/RESTRequestParameterProcessingFilter.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/security/RESTRequestParameterProcessingFilter.java
@@ -39,6 +39,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/service/ApacheCommonsConfigurationService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/ApacheCommonsConfigurationService.java
@@ -1,12 +1,6 @@
 package org.libresonic.player.service;
 
-import com.google.common.collect.Lists;
-import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.configuration2.FileBasedConfiguration;
-import org.apache.commons.configuration2.ImmutableConfiguration;
-import org.apache.commons.configuration2.MapConfiguration;
-import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.configuration2.PropertiesConfigurationLayout;
+import org.apache.commons.configuration2.*;
 import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;

--- a/libresonic-main/src/main/java/org/libresonic/player/service/AudioScrobblerService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/AudioScrobblerService.java
@@ -19,14 +19,6 @@
  */
 package org.libresonic.player.service;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.LinkedBlockingQueue;
-
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.ResponseHandler;
@@ -39,11 +31,14 @@ import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.UserSettings;
 import org.libresonic.player.util.StringUtil;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Provides services for "audioscrobbling", which is the process of

--- a/libresonic-main/src/main/java/org/libresonic/player/service/ITunesParser.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/ITunesParser.java
@@ -19,29 +19,22 @@
 
 package org.libresonic.player.service;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.apache.commons.io.IOUtils;
+import org.libresonic.player.util.StringUtil;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-import org.apache.commons.io.IOUtils;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
-import org.libresonic.player.util.StringUtil;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.*;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/service/JukeboxService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/JukeboxService.java
@@ -19,20 +19,13 @@
  */
 package org.libresonic.player.service;
 
-import java.io.InputStream;
-
 import org.apache.commons.io.IOUtils;
-
 import org.libresonic.player.Logger;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.PlayQueue;
-import org.libresonic.player.domain.Player;
-import org.libresonic.player.domain.Transcoding;
-import org.libresonic.player.domain.TransferStatus;
-import org.libresonic.player.domain.User;
-import org.libresonic.player.domain.VideoTranscodingSettings;
+import org.libresonic.player.domain.*;
 import org.libresonic.player.service.jukebox.AudioPlayer;
 import org.libresonic.player.util.FileUtil;
+
+import java.io.InputStream;
 
 import static org.libresonic.player.service.jukebox.AudioPlayer.State.EOM;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/service/LastFmCache.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/LastFmCache.java
@@ -19,20 +19,14 @@
 
 package org.libresonic.player.service;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Map;
-import java.util.Properties;
-
-import org.apache.commons.io.IOUtils;
-
 import de.umass.lastfm.cache.Cache;
 import de.umass.lastfm.cache.ExpirationPolicy;
 import de.umass.lastfm.cache.FileSystemCache;
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Based on {@link FileSystemCache}, but properly closes files and enforces

--- a/libresonic-main/src/main/java/org/libresonic/player/service/LastFmExpirationPolicy.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/LastFmExpirationPolicy.java
@@ -19,10 +19,10 @@
 
 package org.libresonic.player.service;
 
+import de.umass.lastfm.cache.ExpirationPolicy;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import de.umass.lastfm.cache.ExpirationPolicy;
 
 /**
  * Artist and album info is cached permanently. Everything else is cached one year.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/LastFmService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/LastFmService.java
@@ -19,38 +19,26 @@
 
 package org.libresonic.player.service;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.apache.commons.lang.StringUtils;
-
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
-
 import de.umass.lastfm.Album;
 import de.umass.lastfm.Artist;
 import de.umass.lastfm.Caller;
 import de.umass.lastfm.ImageSize;
 import de.umass.lastfm.Track;
-import de.umass.lastfm.cache.Cache;
-
+import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.Logger;
 import org.libresonic.player.dao.ArtistDao;
 import org.libresonic.player.dao.MediaFileDao;
-import org.libresonic.player.domain.LastFmCoverArt;
-import org.libresonic.player.domain.AlbumNotes;
-import org.libresonic.player.domain.ArtistBio;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.MusicFolder;
+import org.libresonic.player.domain.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Provides services from the Last.fm REST API.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/MediaFileService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/MediaFileService.java
@@ -19,25 +19,10 @@
  */
 package org.libresonic.player.service;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
-
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.Logger;
 import org.libresonic.player.dao.AlbumDao;
 import org.libresonic.player.dao.MediaFileDao;
@@ -47,6 +32,10 @@ import org.libresonic.player.service.metadata.MetaData;
 import org.libresonic.player.service.metadata.MetaDataParser;
 import org.libresonic.player.service.metadata.MetaDataParserFactory;
 import org.libresonic.player.util.FileUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 import static org.libresonic.player.domain.MediaFile.MediaType.*;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/service/MediaScannerService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/MediaScannerService.java
@@ -19,27 +19,16 @@
  */
 package org.libresonic.player.service;
 
-import java.io.File;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-
 import org.apache.commons.lang.ObjectUtils;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.dao.AlbumDao;
 import org.libresonic.player.dao.ArtistDao;
 import org.libresonic.player.dao.MediaFileDao;
-import org.libresonic.player.domain.Album;
-import org.libresonic.player.domain.Artist;
-import org.libresonic.player.domain.Genres;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.MediaLibraryStatistics;
-import org.libresonic.player.domain.MusicFolder;
+import org.libresonic.player.domain.*;
 import org.libresonic.player.util.FileUtil;
+
+import java.io.File;
+import java.util.*;
 
 /**
  * Provides services for scanning the music library.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/MusicIndexService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/MusicIndexService.java
@@ -19,28 +19,15 @@
  */
 package org.libresonic.player.service;
 
+import org.libresonic.player.domain.*;
+import org.libresonic.player.domain.MusicIndex.SortableArtist;
+import org.libresonic.player.util.FileUtil;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.Collator;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.StringTokenizer;
-import java.util.TreeMap;
-
-import org.libresonic.player.domain.Artist;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.MusicFolder;
-import org.libresonic.player.domain.MusicFolderContent;
-import org.libresonic.player.domain.MusicIndex;
-import org.libresonic.player.domain.MusicIndex.SortableArtist;
-import org.libresonic.player.util.FileUtil;
+import java.util.*;
 
 /**
  * Provides services for grouping artists by index.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/NetworkService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/NetworkService.java
@@ -19,15 +19,6 @@
  */
 package org.libresonic.player.service;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
@@ -41,13 +32,21 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.UrlRedirectType;
 import org.libresonic.player.service.upnp.ClingRouter;
 import org.libresonic.player.service.upnp.NATPMPRouter;
 import org.libresonic.player.service.upnp.Router;
 import org.libresonic.player.util.StringUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Provides network-related services, including port forwarding on UPnP routers and

--- a/libresonic-main/src/main/java/org/libresonic/player/service/PlayerService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/PlayerService.java
@@ -19,23 +19,22 @@
  */
 package org.libresonic.player.service;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
-
 import org.libresonic.player.dao.PlayerDao;
 import org.libresonic.player.domain.Player;
 import org.libresonic.player.domain.Transcoding;
 import org.libresonic.player.domain.TransferStatus;
 import org.libresonic.player.domain.User;
 import org.libresonic.player.util.StringUtil;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Provides services for maintaining the set of players.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/PlaylistService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/PlaylistService.java
@@ -19,25 +19,6 @@
  */
 package org.libresonic.player.service;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringEscapeUtils;
@@ -46,7 +27,6 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.dao.MediaFileDao;
 import org.libresonic.player.dao.PlaylistDao;
@@ -57,6 +37,12 @@ import org.libresonic.player.domain.User;
 import org.libresonic.player.util.Pair;
 import org.libresonic.player.util.StringUtil;
 import org.libresonic.player.util.Util;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Provides services for loading and saving playlists to and from persistent storage.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/PodcastService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/PodcastService.java
@@ -19,26 +19,6 @@
  */
 package org.libresonic.player.service;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -57,7 +37,6 @@ import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.dao.PodcastDao;
 import org.libresonic.player.domain.MediaFile;
@@ -68,6 +47,15 @@ import org.libresonic.player.service.metadata.MetaData;
 import org.libresonic.player.service.metadata.MetaDataParser;
 import org.libresonic.player.service.metadata.MetaDataParserFactory;
 import org.libresonic.player.util.StringUtil;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * Provides services for Podcast reception.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/RatingService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/RatingService.java
@@ -19,14 +19,14 @@
  */
 package org.libresonic.player.service;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.libresonic.player.dao.RatingDao;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.MusicFolder;
 import org.libresonic.player.util.FileUtil;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Provides services for user ratings.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/SearchService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/SearchService.java
@@ -19,21 +19,8 @@
  */
 package org.libresonic.player.service;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-
-import org.apache.lucene.analysis.ASCIIFoldingFilter;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.LowerCaseFilter;
-import org.apache.lucene.analysis.StopFilter;
-import org.apache.lucene.analysis.TokenStream;
+import com.google.common.collect.Lists;
+import org.apache.lucene.analysis.*;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.standard.StandardFilter;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
@@ -45,15 +32,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryParser.MultiFieldQueryParser;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.NumericRangeQuery;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.Searcher;
-import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.*;
 import org.apache.lucene.search.spans.SpanOrQuery;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
@@ -61,20 +40,17 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.Version;
-
-import com.google.common.collect.Lists;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.dao.AlbumDao;
 import org.libresonic.player.dao.ArtistDao;
-import org.libresonic.player.domain.Album;
-import org.libresonic.player.domain.Artist;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.MusicFolder;
-import org.libresonic.player.domain.RandomSearchCriteria;
-import org.libresonic.player.domain.SearchCriteria;
-import org.libresonic.player.domain.SearchResult;
+import org.libresonic.player.domain.*;
 import org.libresonic.player.util.FileUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.*;
 
 import static org.libresonic.player.service.SearchService.IndexType.*;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/service/SecurityService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/SecurityService.java
@@ -35,6 +35,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
 
 import javax.servlet.http.HttpServletRequest;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;

--- a/libresonic-main/src/main/java/org/libresonic/player/service/SettingsService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/SettingsService.java
@@ -20,20 +20,12 @@
 package org.libresonic.player.service;
 
 import org.apache.commons.lang.StringUtils;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.dao.AvatarDao;
 import org.libresonic.player.dao.InternetRadioDao;
 import org.libresonic.player.dao.MusicFolderDao;
 import org.libresonic.player.dao.UserDao;
-import org.libresonic.player.domain.AlbumListType;
-import org.libresonic.player.domain.Avatar;
-import org.libresonic.player.domain.InternetRadio;
-import org.libresonic.player.domain.MediaLibraryStatistics;
-import org.libresonic.player.domain.MusicFolder;
-import org.libresonic.player.domain.Theme;
-import org.libresonic.player.domain.UrlRedirectType;
-import org.libresonic.player.domain.UserSettings;
+import org.libresonic.player.domain.*;
 import org.libresonic.player.util.FileUtil;
 import org.libresonic.player.util.StringUtil;
 import org.libresonic.player.util.Util;

--- a/libresonic-main/src/main/java/org/libresonic/player/service/ShareService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/ShareService.java
@@ -19,22 +19,21 @@
  */
 package org.libresonic.player.service;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.RandomStringUtils;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.dao.ShareDao;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.MusicFolder;
 import org.libresonic.player.domain.Share;
 import org.libresonic.player.domain.User;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Provides services for sharing media.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/SonosService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/SonosService.java
@@ -19,17 +19,24 @@
 
 package org.libresonic.player.service;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import com.sonos.services._1.*;
+import com.sonos.services._1_1.SonosSoap;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.cxf.headers.Header;
+import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.jaxb.JAXBDataBinding;
+import org.apache.cxf.jaxws.context.WrappedMessageContext;
+import org.apache.cxf.message.Message;
+import org.libresonic.player.Logger;
+import org.libresonic.player.domain.AlbumListType;
+import org.libresonic.player.domain.MediaFile;
+import org.libresonic.player.domain.Playlist;
+import org.libresonic.player.domain.User;
+import org.libresonic.player.service.sonos.SonosHelper;
+import org.libresonic.player.service.sonos.SonosServiceRegistration;
+import org.libresonic.player.service.sonos.SonosSoapFault;
+import org.w3c.dom.Node;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
@@ -41,60 +48,12 @@ import javax.xml.ws.Holder;
 import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.handler.MessageContext;
 
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.cxf.headers.Header;
-import org.apache.cxf.helpers.CastUtils;
-import org.apache.cxf.jaxb.JAXBDataBinding;
-import org.apache.cxf.jaxws.context.WrappedMessageContext;
-import org.apache.cxf.message.Message;
-import org.w3c.dom.Node;
-
-import com.sonos.services._1.AbstractMedia;
-import com.sonos.services._1.AddToContainerResult;
-import com.sonos.services._1.ContentKey;
-import com.sonos.services._1.CreateContainerResult;
-import com.sonos.services._1.Credentials;
-import com.sonos.services._1.DeleteContainerResult;
-import com.sonos.services._1.DeviceAuthTokenResult;
-import com.sonos.services._1.DeviceLinkCodeResult;
-import com.sonos.services._1.ExtendedMetadata;
-import com.sonos.services._1.GetExtendedMetadata;
-import com.sonos.services._1.GetExtendedMetadataResponse;
-import com.sonos.services._1.GetExtendedMetadataText;
-import com.sonos.services._1.GetExtendedMetadataTextResponse;
-import com.sonos.services._1.GetMediaMetadata;
-import com.sonos.services._1.GetMediaMetadataResponse;
-import com.sonos.services._1.GetMetadata;
-import com.sonos.services._1.GetMetadataResponse;
-import com.sonos.services._1.GetSessionId;
-import com.sonos.services._1.GetSessionIdResponse;
-import com.sonos.services._1.HttpHeaders;
-import com.sonos.services._1.LastUpdate;
-import com.sonos.services._1.MediaCollection;
-import com.sonos.services._1.MediaList;
-import com.sonos.services._1.MediaMetadata;
-import com.sonos.services._1.MediaUriAction;
-import com.sonos.services._1.RateItem;
-import com.sonos.services._1.RateItemResponse;
-import com.sonos.services._1.RelatedBrowse;
-import com.sonos.services._1.RemoveFromContainerResult;
-import com.sonos.services._1.RenameContainerResult;
-import com.sonos.services._1.ReorderContainerResult;
-import com.sonos.services._1.ReportPlaySecondsResult;
-import com.sonos.services._1.Search;
-import com.sonos.services._1.SearchResponse;
-import com.sonos.services._1.SegmentMetadataList;
-import com.sonos.services._1_1.SonosSoap;
-
-import org.libresonic.player.Logger;
-import org.libresonic.player.domain.AlbumListType;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.Playlist;
-import org.libresonic.player.domain.User;
-import org.libresonic.player.service.sonos.SonosHelper;
-import org.libresonic.player.service.sonos.SonosServiceRegistration;
-import org.libresonic.player.service.sonos.SonosSoapFault;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * For manual testing of this service:

--- a/libresonic-main/src/main/java/org/libresonic/player/service/StatusService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/StatusService.java
@@ -20,19 +20,12 @@
 package org.libresonic.player.service;
 
 import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.Player;
 import org.libresonic.player.domain.PlayStatus;
+import org.libresonic.player.domain.Player;
 import org.libresonic.player.domain.TransferStatus;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Provides services for maintaining the list of stream, download and upload statuses.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/TranscodingService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/TranscodingService.java
@@ -19,6 +19,18 @@
  */
 package org.libresonic.player.service;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.filefilter.PrefixFileFilter;
+import org.apache.commons.lang.StringUtils;
+import org.libresonic.player.Logger;
+import org.libresonic.player.controller.VideoPlayerController;
+import org.libresonic.player.dao.TranscodingDao;
+import org.libresonic.player.domain.*;
+import org.libresonic.player.io.TranscodeInputStream;
+import org.libresonic.player.util.StringUtil;
+import org.libresonic.player.util.Util;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -26,24 +38,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.filefilter.PrefixFileFilter;
-import org.apache.commons.lang.StringUtils;
-
-import org.libresonic.player.Logger;
-import org.libresonic.player.controller.VideoPlayerController;
-import org.libresonic.player.dao.TranscodingDao;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.Player;
-import org.libresonic.player.domain.TranscodeScheme;
-import org.libresonic.player.domain.Transcoding;
-import org.libresonic.player.domain.UserSettings;
-import org.libresonic.player.domain.VideoTranscodingSettings;
-import org.libresonic.player.io.TranscodeInputStream;
-import org.libresonic.player.util.StringUtil;
-import org.libresonic.player.util.Util;
 
 /**
  * Provides services for transcoding media. Transcoding is the process of

--- a/libresonic-main/src/main/java/org/libresonic/player/service/UPnPService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/UPnPService.java
@@ -19,23 +19,11 @@
  */
 package org.libresonic.player.service;
 
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.fourthline.cling.UpnpService;
 import org.fourthline.cling.UpnpServiceImpl;
 import org.fourthline.cling.binding.annotations.AnnotationLocalServiceBinder;
 import org.fourthline.cling.model.DefaultServiceManager;
-import org.fourthline.cling.model.meta.Device;
-import org.fourthline.cling.model.meta.DeviceDetails;
-import org.fourthline.cling.model.meta.DeviceIdentity;
-import org.fourthline.cling.model.meta.Icon;
-import org.fourthline.cling.model.meta.LocalDevice;
-import org.fourthline.cling.model.meta.LocalService;
-import org.fourthline.cling.model.meta.ManufacturerDetails;
-import org.fourthline.cling.model.meta.ModelDetails;
-import org.fourthline.cling.model.meta.RemoteDevice;
+import org.fourthline.cling.model.meta.*;
 import org.fourthline.cling.model.types.DLNADoc;
 import org.fourthline.cling.model.types.DeviceType;
 import org.fourthline.cling.model.types.UDADeviceType;
@@ -44,12 +32,15 @@ import org.fourthline.cling.support.connectionmanager.ConnectionManagerService;
 import org.fourthline.cling.support.model.ProtocolInfos;
 import org.fourthline.cling.support.model.dlna.DLNAProfiles;
 import org.fourthline.cling.support.model.dlna.DLNAProtocolInfo;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.Version;
 import org.libresonic.player.service.upnp.ApacheUpnpServiceConfiguration;
 import org.libresonic.player.service.upnp.FolderBasedContentDirectory;
 import org.libresonic.player.service.upnp.MSMediaReceiverRegistrarService;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/service/VersionService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/VersionService.java
@@ -19,17 +19,6 @@
  */
 package org.libresonic.player.service;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.StringReader;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
@@ -37,9 +26,15 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.Version;
+
+import java.io.*;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Provides version-related services, including functionality for determining whether a newer

--- a/libresonic-main/src/main/java/org/libresonic/player/service/jukebox/AudioPlayer.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/jukebox/AudioPlayer.java
@@ -19,19 +19,18 @@
  */
 package org.libresonic.player.service.jukebox;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.io.IOUtils;
+import org.libresonic.player.Logger;
+import org.libresonic.player.service.JukeboxService;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.FloatControl;
 import javax.sound.sampled.SourceDataLine;
 
-import org.apache.commons.io.IOUtils;
-
-import org.libresonic.player.Logger;
-import org.libresonic.player.service.JukeboxService;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.libresonic.player.service.jukebox.AudioPlayer.State.*;
 

--- a/libresonic-main/src/main/java/org/libresonic/player/service/jukebox/PlayerTest.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/jukebox/PlayerTest.java
@@ -3,6 +3,7 @@ package org.libresonic.player.service.jukebox;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;

--- a/libresonic-main/src/main/java/org/libresonic/player/service/metadata/FFmpegParser.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/metadata/FFmpegParser.java
@@ -19,13 +19,13 @@
  */
 package org.libresonic.player.service.metadata;
 
+import org.apache.commons.io.FilenameUtils;
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.io.InputStreamReaderThread;
 import org.libresonic.player.service.ServiceLocator;
 import org.libresonic.player.service.TranscodingService;
 import org.libresonic.player.util.StringUtil;
-import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.InputStream;

--- a/libresonic-main/src/main/java/org/libresonic/player/service/metadata/JaudiotaggerParser.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/metadata/JaudiotaggerParser.java
@@ -19,8 +19,6 @@
  */
 package org.libresonic.player.service.metadata;
 
-import org.libresonic.player.Logger;
-import org.libresonic.player.domain.MediaFile;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jaudiotagger.audio.AudioFile;
@@ -30,6 +28,8 @@ import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.Tag;
 import org.jaudiotagger.tag.datatype.Artwork;
 import org.jaudiotagger.tag.reference.GenreTypes;
+import org.libresonic.player.Logger;
+import org.libresonic.player.domain.MediaFile;
 
 import java.io.File;
 import java.util.SortedSet;

--- a/libresonic-main/src/main/java/org/libresonic/player/service/metadata/MetaDataParser.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/metadata/MetaDataParser.java
@@ -19,12 +19,12 @@
  */
 package org.libresonic.player.service.metadata;
 
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.MusicFolder;
 import org.libresonic.player.service.ServiceLocator;
 import org.libresonic.player.service.SettingsService;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
 
 import java.io.File;
 import java.util.List;

--- a/libresonic-main/src/main/java/org/libresonic/player/service/sonos/AlbumList.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/sonos/AlbumList.java
@@ -19,9 +19,9 @@
 
 package org.libresonic.player.service.sonos;
 
-import java.util.List;
-
 import org.libresonic.player.domain.MediaFile;
+
+import java.util.List;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/service/sonos/SonosFaultInterceptor.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/sonos/SonosFaultInterceptor.java
@@ -19,17 +19,16 @@
 
 package org.libresonic.player.service.sonos;
 
-import javax.xml.namespace.QName;
-
 import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.binding.soap.interceptor.AbstractSoapInterceptor;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.phase.Phase;
+import org.libresonic.player.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import org.libresonic.player.Logger;
+import javax.xml.namespace.QName;
 
 /**
  * Intercepts all SonosSoapFault exceptions and builds a SOAP Fault.

--- a/libresonic-main/src/main/java/org/libresonic/player/service/sonos/SonosHelper.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/sonos/SonosHelper.java
@@ -19,58 +19,22 @@
 
 package org.libresonic.player.service.sonos;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.commons.lang.StringUtils;
-import org.springframework.web.bind.ServletRequestUtils;
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.sonos.services._1.AbstractMedia;
-import com.sonos.services._1.AlbumArtUrl;
-import com.sonos.services._1.ItemType;
-import com.sonos.services._1.MediaCollection;
-import com.sonos.services._1.MediaList;
-import com.sonos.services._1.MediaMetadata;
-import com.sonos.services._1.TrackMetadata;
-
+import com.sonos.services._1.*;
+import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.controller.CoverArtController;
 import org.libresonic.player.dao.MediaFileDao;
-import org.libresonic.player.domain.AlbumListType;
-import org.libresonic.player.domain.CoverArtScheme;
-import org.libresonic.player.domain.Genre;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.MusicFolder;
-import org.libresonic.player.domain.MusicFolderContent;
-import org.libresonic.player.domain.MusicIndex;
-import org.libresonic.player.domain.Player;
-import org.libresonic.player.domain.PlayerTechnology;
-import org.libresonic.player.domain.Playlist;
-import org.libresonic.player.domain.PodcastChannel;
-import org.libresonic.player.domain.PodcastEpisode;
-import org.libresonic.player.domain.PodcastStatus;
-import org.libresonic.player.domain.SearchCriteria;
-import org.libresonic.player.domain.SearchResult;
-import org.libresonic.player.service.LastFmService;
-import org.libresonic.player.service.MediaFileService;
-import org.libresonic.player.service.MusicIndexService;
-import org.libresonic.player.service.PlayerService;
-import org.libresonic.player.service.PlaylistService;
-import org.libresonic.player.service.PodcastService;
-import org.libresonic.player.service.RatingService;
-import org.libresonic.player.service.SearchService;
-import org.libresonic.player.service.SettingsService;
-import org.libresonic.player.service.SonosService;
-import org.libresonic.player.service.TranscodingService;
+import org.libresonic.player.domain.*;
+import org.libresonic.player.service.*;
 import org.libresonic.player.util.StringUtil;
 import org.libresonic.player.util.Util;
+import org.springframework.web.bind.ServletRequestUtils;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.*;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/service/sonos/SonosServiceRegistration.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/sonos/SonosServiceRegistration.java
@@ -19,10 +19,6 @@
 
 package org.libresonic.player.service.sonos;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.http.NameValuePair;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
@@ -33,10 +29,13 @@ import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
-
 import org.libresonic.player.Logger;
 import org.libresonic.player.util.Pair;
 import org.libresonic.player.util.StringUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/service/upnp/ApacheUpnpServiceConfiguration.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/upnp/ApacheUpnpServiceConfiguration.java
@@ -19,8 +19,6 @@
  */
 package org.libresonic.player.service.upnp;
 
-import java.util.concurrent.Executors;
-
 import org.fourthline.cling.DefaultUpnpServiceConfiguration;
 import org.fourthline.cling.transport.impl.apache.StreamClientConfigurationImpl;
 import org.fourthline.cling.transport.impl.apache.StreamClientImpl;
@@ -29,6 +27,8 @@ import org.fourthline.cling.transport.impl.apache.StreamServerImpl;
 import org.fourthline.cling.transport.spi.NetworkAddressFactory;
 import org.fourthline.cling.transport.spi.StreamClient;
 import org.fourthline.cling.transport.spi.StreamServer;
+
+import java.util.concurrent.Executors;
 
 /**
  * UPnP configuration which uses Apache HttpComponents.  Needed to make UPnP work

--- a/libresonic-main/src/main/java/org/libresonic/player/service/upnp/ClingRouter.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/upnp/ClingRouter.java
@@ -19,12 +19,6 @@
  */
 package org.libresonic.player.service.upnp;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Collection;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.fourthline.cling.UpnpService;
 import org.fourthline.cling.model.action.ActionInvocation;
 import org.fourthline.cling.model.message.UpnpResponse;
@@ -34,8 +28,13 @@ import org.fourthline.cling.support.igd.PortMappingListener;
 import org.fourthline.cling.support.igd.callback.PortMappingAdd;
 import org.fourthline.cling.support.igd.callback.PortMappingDelete;
 import org.fourthline.cling.support.model.PortMapping;
-
 import org.libresonic.player.service.UPnPService;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
 * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/service/upnp/FolderBasedContentDirectory.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/upnp/FolderBasedContentDirectory.java
@@ -19,36 +19,25 @@
  */
 package org.libresonic.player.service.upnp;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.List;
-
 import org.fourthline.cling.support.contentdirectory.ContentDirectoryErrorCode;
 import org.fourthline.cling.support.contentdirectory.ContentDirectoryException;
-import org.fourthline.cling.support.model.BrowseFlag;
-import org.fourthline.cling.support.model.BrowseResult;
-import org.fourthline.cling.support.model.DIDLContent;
-import org.fourthline.cling.support.model.DIDLObject;
-import org.fourthline.cling.support.model.PersonWithRole;
-import org.fourthline.cling.support.model.SortCriterion;
-import org.fourthline.cling.support.model.WriteStatus;
+import org.fourthline.cling.support.model.*;
 import org.fourthline.cling.support.model.container.Container;
 import org.fourthline.cling.support.model.container.MusicAlbum;
 import org.fourthline.cling.support.model.container.PlaylistContainer;
 import org.fourthline.cling.support.model.container.StorageFolder;
 import org.fourthline.cling.support.model.item.Item;
 import org.fourthline.cling.support.model.item.MusicTrack;
-
 import org.libresonic.player.Logger;
-import org.libresonic.player.domain.CoverArtScheme;
-import org.libresonic.player.domain.MediaFile;
-import org.libresonic.player.domain.MediaLibraryStatistics;
-import org.libresonic.player.domain.MusicFolder;
-import org.libresonic.player.domain.Playlist;
+import org.libresonic.player.domain.*;
 import org.libresonic.player.service.MediaFileService;
 import org.libresonic.player.service.PlaylistService;
 import org.libresonic.player.util.Util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/service/upnp/LibresonicContentDirectory.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/upnp/LibresonicContentDirectory.java
@@ -28,14 +28,13 @@ import org.fourthline.cling.support.model.BrowseResult;
 import org.fourthline.cling.support.model.DIDLContent;
 import org.fourthline.cling.support.model.Res;
 import org.fourthline.cling.support.model.SortCriterion;
-import org.seamless.util.MimeType;
-
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.Player;
 import org.libresonic.player.service.PlayerService;
 import org.libresonic.player.service.SettingsService;
 import org.libresonic.player.service.TranscodingService;
 import org.libresonic.player.util.StringUtil;
+import org.seamless.util.MimeType;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/spring/LoggingExceptionResolver.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/spring/LoggingExceptionResolver.java
@@ -1,11 +1,12 @@
 package org.libresonic.player.spring;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.libresonic.player.Logger;
 import org.springframework.core.Ordered;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public class LoggingExceptionResolver implements HandlerExceptionResolver, Ordered {
 

--- a/libresonic-main/src/main/java/org/libresonic/player/taglib/EscapeJavaScriptTag.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/taglib/EscapeJavaScriptTag.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringEscapeUtils;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspTagException;
 import javax.servlet.jsp.tagext.BodyTagSupport;
+
 import java.io.IOException;
 
 /**

--- a/libresonic-main/src/main/java/org/libresonic/player/taglib/FormatBytesTag.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/taglib/FormatBytesTag.java
@@ -19,14 +19,16 @@
  */
 package org.libresonic.player.taglib;
 
-import org.libresonic.player.util.*;
-import org.springframework.web.servlet.support.*;
+import org.libresonic.player.util.StringUtil;
+import org.springframework.web.servlet.support.RequestContextUtils;
 
-import javax.servlet.http.*;
-import javax.servlet.jsp.*;
-import javax.servlet.jsp.tagext.*;
-import java.io.*;
-import java.util.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspTagException;
+import javax.servlet.jsp.tagext.BodyTagSupport;
+
+import java.io.IOException;
+import java.util.Locale;
 
 /**
  * Converts a byte-count to a formatted string suitable for display to the user, with respect

--- a/libresonic-main/src/main/java/org/libresonic/player/taglib/ParamTag.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/taglib/ParamTag.java
@@ -19,8 +19,8 @@
  */
 package org.libresonic.player.taglib;
 
-import javax.servlet.jsp.tagext.*;
-import javax.servlet.jsp.*;
+import javax.servlet.jsp.JspTagException;
+import javax.servlet.jsp.tagext.TagSupport;
 
 /**
  * A tag representing an URL query parameter.

--- a/libresonic-main/src/main/java/org/libresonic/player/taglib/UrlTag.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/taglib/UrlTag.java
@@ -19,16 +19,17 @@
  */
 package org.libresonic.player.taglib;
 
+import org.apache.commons.lang.CharUtils;
+import org.apache.taglibs.standard.tag.common.core.UrlSupport;
 import org.libresonic.player.Logger;
 import org.libresonic.player.filter.ParameterDecodingFilter;
 import org.libresonic.player.util.StringUtil;
-import org.apache.taglibs.standard.tag.common.core.UrlSupport;
-import org.apache.commons.lang.CharUtils;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspTagException;
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.BodyTagSupport;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;

--- a/libresonic-main/src/main/java/org/libresonic/player/taglib/WikiTag.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/taglib/WikiTag.java
@@ -19,15 +19,17 @@
  */
 package org.libresonic.player.taglib;
 
-import org.radeox.api.engine.*;
-import org.radeox.api.engine.context.*;
-import org.radeox.engine.*;
-import org.radeox.engine.context.*;
-import org.apache.commons.lang.*;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.radeox.api.engine.RenderEngine;
+import org.radeox.api.engine.context.RenderContext;
+import org.radeox.engine.BaseRenderEngine;
+import org.radeox.engine.context.BaseRenderContext;
 
-import javax.servlet.jsp.*;
-import javax.servlet.jsp.tagext.*;
-import java.io.*;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspTagException;
+import javax.servlet.jsp.tagext.BodyTagSupport;
+
+import java.io.IOException;
 
 /**
  * Renders a Wiki text with markup to HTML, using the Radeox render engine.

--- a/libresonic-main/src/main/java/org/libresonic/player/theme/LibresonicThemeResolver.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/theme/LibresonicThemeResolver.java
@@ -19,12 +19,17 @@
  */
 package org.libresonic.player.theme;
 
-import org.libresonic.player.service.*;
-import org.libresonic.player.domain.*;
-import org.springframework.web.servlet.*;
+import org.libresonic.player.domain.Theme;
+import org.libresonic.player.domain.UserSettings;
+import org.libresonic.player.service.SecurityService;
+import org.libresonic.player.service.SettingsService;
+import org.springframework.web.servlet.ThemeResolver;
 
-import javax.servlet.http.*;
-import java.util.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Theme resolver implementation which returns the theme selected in the settings.

--- a/libresonic-main/src/main/java/org/libresonic/player/theme/LibresonicThemeSource.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/theme/LibresonicThemeSource.java
@@ -19,12 +19,11 @@
  */
 package org.libresonic.player.theme;
 
-import org.springframework.ui.context.support.ResourceBundleThemeSource;
-import org.springframework.context.MessageSource;
-import org.springframework.context.support.ResourceBundleMessageSource;
-
 import org.libresonic.player.domain.Theme;
 import org.libresonic.player.service.SettingsService;
+import org.springframework.context.MessageSource;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.ui.context.support.ResourceBundleThemeSource;
 
 /**
  * Theme source implementation which uses two resource bundles: the

--- a/libresonic-main/src/main/java/org/libresonic/player/upload/MonitoredDiskFileItem.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/upload/MonitoredDiskFileItem.java
@@ -22,8 +22,8 @@ package org.libresonic.player.upload;
 import org.apache.commons.fileupload.disk.DiskFileItem;
 
 import java.io.File;
-import java.io.OutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Extension of Commons FileUpload for monitoring the upload progress.

--- a/libresonic-main/src/main/java/org/libresonic/player/upload/MonitoredOutputStream.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/upload/MonitoredOutputStream.java
@@ -19,8 +19,8 @@
  */
 package org.libresonic.player.upload;
 
-import java.io.OutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Extension of Commons FileUpload for monitoring the upload progress.

--- a/libresonic-main/src/main/java/org/libresonic/player/util/BoundedList.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/util/BoundedList.java
@@ -19,7 +19,7 @@
  */
 package org.libresonic.player.util;
 
-import java.util.*;
+import java.util.LinkedList;
 
 /**
  * Simple implementation of a bounded list. If the maximum size is reached, adding a new element will

--- a/libresonic-main/src/main/java/org/libresonic/player/util/FileUtil.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/util/FileUtil.java
@@ -19,13 +19,13 @@
  */
 package org.libresonic.player.util;
 
+import org.libresonic.player.Logger;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Arrays;
-
-import org.libresonic.player.Logger;
 
 /**
  * Miscellaneous file utility methods.

--- a/libresonic-main/src/main/java/org/libresonic/player/util/HttpRange.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/util/HttpRange.java
@@ -19,10 +19,10 @@
  */
 package org.libresonic.player.util;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.commons.lang.StringUtils;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/util/Pair.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/util/Pair.java
@@ -19,9 +19,9 @@
  */
 package org.libresonic.player.util;
 
-import java.io.Serializable;
-
 import org.apache.commons.lang.ObjectUtils;
+
+import java.io.Serializable;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/main/java/org/libresonic/player/util/StringUtil.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/util/StringUtil.java
@@ -19,34 +19,24 @@
  */
 package org.libresonic.player.util;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.libresonic.player.domain.UrlRedirectType;
+
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.security.MessageDigest;
-import java.text.DateFormat;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
-import java.text.SimpleDateFormat;
+import java.text.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-
-import org.libresonic.player.domain.UrlRedirectType;
 
 /**
  * Miscellaneous string utility methods.

--- a/libresonic-main/src/main/java/org/libresonic/player/util/Util.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/util/Util.java
@@ -19,21 +19,16 @@
  */
 package org.libresonic.player.util;
 
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Random;
+import org.libresonic.player.Logger;
+import org.libresonic.player.service.SettingsService;
 
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
-import org.libresonic.player.Logger;
-import org.libresonic.player.service.SettingsService;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.*;
 
 /**
  * Miscellaneous general utility methods.

--- a/libresonic-main/src/main/java/org/libresonic/player/validator/PasswordSettingsValidator.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/validator/PasswordSettingsValidator.java
@@ -19,10 +19,11 @@
  */
 package org.libresonic.player.validator;
 
+import org.libresonic.player.command.PasswordSettingsCommand;
+import org.libresonic.player.controller.PasswordSettingsController;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.*;
-import org.libresonic.player.command.*;
-import org.libresonic.player.controller.*;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
 
 /**
  * Validator for {@link PasswordSettingsController}.

--- a/libresonic-main/src/main/java/org/libresonic/player/validator/UserSettingsValidator.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/validator/UserSettingsValidator.java
@@ -19,11 +19,11 @@
  */
 package org.libresonic.player.validator;
 
+import org.apache.commons.lang.StringUtils;
 import org.libresonic.player.command.UserSettingsCommand;
 import org.libresonic.player.controller.UserSettingsController;
 import org.libresonic.player.service.SecurityService;
 import org.libresonic.player.service.SettingsService;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;

--- a/libresonic-main/src/test/java/org/libresonic/player/controller/HLSControllerTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/controller/HLSControllerTestCase.java
@@ -19,10 +19,10 @@
  */
 package org.libresonic.player.controller;
 
-import java.awt.Dimension;
-
 import junit.framework.TestCase;
 import org.libresonic.player.util.Pair;
+
+import java.awt.*;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/test/java/org/libresonic/player/controller/StreamControllerTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/controller/StreamControllerTestCase.java
@@ -19,9 +19,9 @@
  */
 package org.libresonic.player.controller;
 
-import java.awt.Dimension;
-
 import junit.framework.TestCase;
+
+import java.awt.*;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/test/java/org/libresonic/player/dao/DaoTestCaseBase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/dao/DaoTestCaseBase.java
@@ -1,6 +1,5 @@
 package org.libresonic.player.dao;
 
-import javax.sql.DataSource;
 import junit.framework.TestCase;
 import liquibase.exception.LiquibaseException;
 import org.libresonic.player.TestCaseUtils;
@@ -10,8 +9,9 @@ import org.libresonic.player.util.FileUtil;
 import org.libresonic.player.util.Util;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
 
 import java.io.File;
 import java.util.HashMap;

--- a/libresonic-main/src/test/java/org/libresonic/player/domain/PlayQueueTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/domain/PlayQueueTestCase.java
@@ -19,13 +19,13 @@
  */
 package org.libresonic.player.domain;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-
 import junit.framework.TestCase;
 import org.libresonic.player.domain.PlayQueue.SortOrder;
 import org.libresonic.player.domain.PlayQueue.Status;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Unit test of {@link PlayQueue}.

--- a/libresonic-main/src/test/java/org/libresonic/player/domain/SortableArtistTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/domain/SortableArtistTestCase.java
@@ -19,13 +19,13 @@
 
 package org.libresonic.player.domain;
 
+import junit.framework.TestCase;
+
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-
-import junit.framework.TestCase;
 
 public class SortableArtistTestCase extends TestCase {
 

--- a/libresonic-main/src/test/java/org/libresonic/player/domain/TranscodeSchemeTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/domain/TranscodeSchemeTestCase.java
@@ -20,6 +20,7 @@
 package org.libresonic.player.domain;
 
 import junit.framework.TestCase;
+
 import static org.libresonic.player.domain.TranscodeScheme.*;
 
 /**

--- a/libresonic-main/src/test/java/org/libresonic/player/domain/VersionTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/domain/VersionTestCase.java
@@ -24,7 +24,7 @@ package org.libresonic.player.domain;
  * @author Sindre Mehus
  */
 
-import junit.framework.*;
+import junit.framework.TestCase;
 
 public class VersionTestCase extends TestCase {
 

--- a/libresonic-main/src/test/java/org/libresonic/player/io/RangeOutputStreamTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/io/RangeOutputStreamTestCase.java
@@ -22,11 +22,7 @@ package org.libresonic.player.io;
 import junit.framework.TestCase;
 import org.libresonic.player.util.HttpRange;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 
 /**
  * @author Sindre Mehus

--- a/libresonic-main/src/test/java/org/libresonic/player/service/SecurityServiceTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/service/SecurityServiceTestCase.java
@@ -19,7 +19,7 @@
  */
 package org.libresonic.player.service;
 
-import junit.framework.*;
+import junit.framework.TestCase;
 /**
  * Unit test of {@link SecurityService}.
  *

--- a/libresonic-main/src/test/java/org/libresonic/player/service/SettingsServiceTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/service/SettingsServiceTestCase.java
@@ -19,13 +19,12 @@
  */
 package org.libresonic.player.service;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Locale;
-
 import junit.framework.TestCase;
 import org.libresonic.player.TestCaseUtils;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Unit test of {@link SettingsService}.

--- a/libresonic-main/src/test/java/org/libresonic/player/service/metadata/MetaDataParserTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/service/metadata/MetaDataParserTestCase.java
@@ -19,10 +19,10 @@
  */
 package org.libresonic.player.service.metadata;
 
-import java.io.File;
-
 import junit.framework.TestCase;
 import org.libresonic.player.domain.MediaFile;
+
+import java.io.File;
 
 /**
  * Unit test of {@link MetaDataParser}.

--- a/libresonic-main/src/test/java/org/libresonic/player/util/FileUtils.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/util/FileUtils.java
@@ -2,13 +2,7 @@ package org.libresonic.player.util;
 
 import org.apache.commons.lang.StringUtils;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLConnection;

--- a/libresonic-main/src/test/java/org/libresonic/player/util/StringUtilTestCase.java
+++ b/libresonic-main/src/test/java/org/libresonic/player/util/StringUtilTestCase.java
@@ -19,12 +19,12 @@
  */
 package org.libresonic.player.util;
 
+import junit.framework.TestCase;
+import org.libresonic.player.domain.UrlRedirectType;
+
 import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.Locale;
-
-import junit.framework.TestCase;
-import org.libresonic.player.domain.UrlRedirectType;
 
 /**
  * Unit test of {@link StringUtil}.

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,33 @@
                         <failOnMissingWebXml>false</failOnMissingWebXml>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>2.17</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>7.4</version>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <id>validate</id>
+                            <phase>validate</phase>
+                            <configuration>
+                                <configLocation>${project.basedir}/../checkstyle.xml</configLocation>
+                                <encoding>UTF-8</encoding>
+                                <consoleOutput>true</consoleOutput>
+                                <failOnViolation>true</failOnViolation>
+                            </configuration>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
Fixes #127. This standardizes the import ordering enforced using a checkstyle maven plugin. The import order is:

third party
blank line
javax
blank line
java
blank line
static imports

Star imports are allowed with the idea that they are unlikely to cause merge conflicts.