### PR TITLE
Fix CSRF issue in shuffle radio

### DIFF
--- a/libresonic-main/src/main/webapp/WEB-INF/jsp/more.jsp
+++ b/libresonic-main/src/main/webapp/WEB-INF/jsp/more.jsp
@@ -62,6 +62,7 @@
             } catch(e) { return; }
             elements = form.getElementsByTagName("input");
             for (var i = 0; i < elements.length; i++) {
+                if (elements[i].type == "hidden") continue;
                 if (elements[i].type == "submit") continue;
                 if (data[elements[i].name]) elements[i].value = data[elements[i].name];
             }
@@ -87,9 +88,17 @@
             var data = {}
             var elements = [];
             elements = form.getElementsByTagName("input");
-            for (var i = 0; i < elements.length; i++) data[elements[i].name] = elements[i].value;
+            for (var i = 0; i < elements.length; i++) {
+                if (elements[i].type == "hidden") continue;
+                if (elements[i].type == "submit") continue;
+                data[elements[i].name] = elements[i].value;
+            }
             elements = form.getElementsByTagName("select");
-            for (var i = 0; i < elements.length; i++) data[elements[i].name] = elements[i].value;
+            for (var i = 0; i < elements.length; i++) {
+                if (elements[i].type == "hidden") continue;
+                if (elements[i].type == "submit") continue;
+                data[elements[i].name] = elements[i].value;
+            }
             localStorage.setItem("randomPlayQueue", JSON.stringify(data));
         }
 


### PR DESCRIPTION
For convenience, shuffle radio filters were saved and restored when
loading the `more.view` page. This also happened for the `_csrf` field,
which caused it to take an old and invalid value.