### PR TITLE
Fix status page crash

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/controller/StatusController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/StatusController.java
@@ -80,7 +80,7 @@ public class StatusController {
     }
 
 
-    private static class TransferStatusHolder {
+    public static class TransferStatusHolder {
         private TransferStatus transferStatus;
         private boolean isStream;
         private boolean isDownload;


### PR DESCRIPTION
The crash occurs because the corresponding JSP template tries to access an inner class recently changed from `public` to `private`.