### PR TITLE
Avoid direct dependency on tomcat

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/boot/TomcatApplication.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/boot/TomcatApplication.java
@@ -1,0 +1,34 @@
+package org.libresonic.player.boot;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Wrapper;
+import org.apache.catalina.webresources.StandardRoot;
+import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+
+public class TomcatApplication {
+
+    public static void configure(TomcatEmbeddedServletContainerFactory tomcatFactory) {
+
+            tomcatFactory.addContextCustomizers((TomcatContextCustomizer) context -> {
+
+                // Increase the size and time before eviction of the Tomcat
+                // cache so that resources aren't uncompressed too often.
+                // See https://github.com/jhipster/generator-jhipster/issues/3995
+
+                StandardRoot resources = new StandardRoot();
+                resources.setCacheMaxSize(100000);
+                resources.setCacheObjectMaxSize(4000);
+                resources.setCacheTtl(24 * 3600 * 1000);  // 1 day, in milliseconds
+                context.setResources(resources);
+
+                // Put Jasper in production mode so that JSP aren't recompiled
+                // on each request.
+                // See http://stackoverflow.com/questions/29653326/spring-boot-application-slow-because-of-jsp-compilation
+                Container jsp = context.findChild("jsp");
+                if (jsp instanceof Wrapper) {
+                    ((Wrapper) jsp).addInitParameter("development", "false");
+                }
+            });
+    }
+}


### PR DESCRIPTION
Use reflection to invoke tomcat configs. This ensures that we dont have a direct dependency on tomcat and can run on any application server, not just tomcat. Fixes #279 

Signed-off-by: Andrew DeMaria <lostonamountain@gmail.com>
