### PR TITLE
undue stacktrace in libresonic.log

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/service/NetworkService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/NetworkService.java
@@ -42,11 +42,8 @@ public class NetworkService {
 
     public static String getBaseUrl(HttpServletRequest request) {
         try {
-            URI uri;
-            try {
-                uri = calculateProxyUri(request);
-            } catch (Exception e) {
-                LOG.debug("Could not calculate proxy uri", e);
+            URI uri = calculateProxyUri(request);
+            if (uri == null) {
                 uri = calculateNonProxyUri(request);
             }
 
@@ -63,7 +60,8 @@ public class NetworkService {
         if(!isValidXForwardedHost(xForardedHost)) {
             xForardedHost = request.getHeader(X_FORWARDED_SERVER);
             if(!isValidXForwardedHost(xForardedHost)) {
-                throw new RuntimeException("Cannot calculate proxy uri without HTTP header " + X_FORWARDED_HOST);
+                LOG.debug("Cannot calculate proxy uri without HTTP header " + X_FORWARDED_HOST);
+                return null;
             }
         }
 


### PR DESCRIPTION
My libresonic.log is plenty of that error.
This PR fixes it. 

```
[2017-03-14 22:00:04,025] DEBUG NetworkService - Calculated base url to http://localhost:8080/
[2017-03-14 22:00:11,363] DEBUG NetworkService - Could not calculate proxy uri
java.lang.RuntimeException: Cannot calculate proxy uri without HTTP header X-Forwarded-Host
	at org.libresonic.player.service.NetworkService.calculateProxyUri(NetworkService.java:66)
	at org.libresonic.player.service.NetworkService.getBaseUrl(NetworkService.java:47)
	at org.libresonic.player.ajax.NowPlayingService.convert(NowPlayingService.java:91)
	at org.libresonic.player.ajax.NowPlayingService.getNowPlaying(NowPlayingService.java:75)
	at org.libresonic.player.ajax.NowPlayingService.getNowPlayingForCurrentPlayer(NowPlayingService.java:60)
...
```