### PR TITLE
remove outdated note haproxy docs

### DIFF
--- a/documentation/PROXY.md
+++ b/documentation/PROXY.md
@@ -116,8 +116,6 @@ The following configuration works for Apache (without HTTPS):
 
 ### HAProxy
 
-**OUTDATED since `X-Forwarded-Host`/`X-FORWARDED-PROTO` change**
-
 The following configuration works for HAProxy (HTTP and HTTPS):
 
 ```haproxy


### PR DESCRIPTION
I tested the current configuration, and it works perfectly ! even with SSL
with tomcat 8 and libresonic-6.2beta1

fix #298 