### PR TITLE
[DEV Only] Jetty Embedded Support

### DIFF
--- a/libresonic-main/pom.xml
+++ b/libresonic-main/pom.xml
@@ -45,15 +45,17 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-tomcat</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-jasper</artifactId>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>javax.servlet.jsp-api</artifactId>
+            <version>2.3.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -393,6 +395,31 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.24</version>
         </dependency>
+
+
+        <!-- Embedded tomcat -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Embedded Jetty -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>apache-jsp</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -409,6 +436,8 @@
                 <configuration>
                     <mainClass>org.libresonic.player.boot.Application</mainClass>
                     <layout>WAR</layout>
+                    <excludeGroupIds>${boot.group.excludes}</excludeGroupIds>
+                    <excludeArtifactIds>${boot.artifact.excludes}</excludeArtifactIds>
                 </configuration>
                 <executions>
                     <execution>
@@ -467,4 +496,23 @@
 
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>tomcat-embed</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <boot.group.excludes>org.eclipse.jetty,org.eclipse.jetty.websocket,org.mortbay.jasper,org.eclipse.jetty.toolchain,org.ow2.asm</boot.group.excludes>
+                <boot.artifact.excludes>spring-boot-starter-jetty</boot.artifact.excludes>
+            </properties>
+        </profile>
+        <profile>
+            <id>jetty-embed</id>
+            <properties>
+                <boot.group.excludes>org.apache.tomcat.embed</boot.group.excludes>
+                <boot.artifact.excludes>spring-boot-starter-tomcat</boot.artifact.excludes>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Users, please ignore this. We are still going to ship with tomcat embedded for the near future, this just adds jetty for devs to evaluate any benefits. You can still deploy the distributed War onto Jetty if desired.

Spring boot supports both Jetty and Tomcat, however only one is supposed
to be used at a time. This is problematic for us, because we would like
to have both on the classpath so we can configure them (i.e.
org.libresonic.player.boot.TomcatApplication). To remedy this, we mark
both as provided, but have two profiles which then tell spring to
exclude one or the other from the lib-provided war. These exclude rules
are a bit fragile, but can be reproduced by analyzing mvn
dependency:tree output.

Signed-off-by: Andrew DeMaria <lostonamountain@gmail.com>
