### PR TITLE
Remove broken login link from login.insecure message.

### DIFF
--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_ca.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_ca.properties
@@ -29,7 +29,7 @@ login.login = Iniciar sessi\u00F3
 login.remember = Recordat
 login.logout = Desconnexi\u00F3 correcta.
 login.error = Usuari o contrasenya incorrecta.
-login.insecure = {0} no \u00E9s segur. Si us plau inicieu sessi\u00F3 amb usuari<br>i contrasenya "admin", o cliqui <a href="login.view?user=admin&amp;password=admin">aqu\u00ED</a>. Tot seguit, canvi\u00EF la contrasenya el m\u00E9s r\u00E0pid possible.
+login.insecure = {0} no \u00E9s segur. Si us plau inicieu sessi\u00F3 amb usuari<br>i contrasenya "admin". Tot seguit, canvi\u00EF la contrasenya el m\u00E9s r\u00E0pid possible.
 
 # accessDenied.jsp
 accessDenied.title = Acc\u00E9s denegat

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_da.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_da.properties
@@ -28,7 +28,7 @@ login.login = Log in
 login.remember = Husk mig
 login.logout = Du er nu logget ud, Tak for bes\u00F8get.
 login.error = Forkert brugernavn eller password
-login.insecure = {0} er ikke sikret. Log ind med brugernavn og <br> password "admin", eller klik p\u00E5 <a href="login.view?user=admin&amp;password=admin">her</a>. Derefter \u00E6ndre adgangskode \u00F8jeblikkeligt.
+login.insecure = {0} er ikke sikret. Log ind med brugernavn og <br> password "admin". Derefter \u00E6ndre adgangskode \u00F8jeblikkeligt.
 
 # AccessDenied.jsp
 accessDenied.title = Ingen adgang

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_de.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_de.properties
@@ -34,7 +34,7 @@ login.login = Einloggen
 login.remember = Login speichern
 login.logout = Ausgeloggt
 login.error = Falscher Benutzername oder Passwort
-login.insecure = {0} ist nicht gesichert. Bitte log dich mit dem Benutzernamen und<br>Password "admin", ein oder klicke <a href="login.view?user=admin&amp;password=admin">hier</a>. Danach \u00E4ndern sie sofort ihr Passwort.
+login.insecure = {0} ist nicht gesichert. Bitte log dich mit dem Benutzernamen und<br>Password "admin" ein. \u00C4ndere danach sofort das Passwort.
 login.recover = Passwort vergessen?
 
 # recover.jsp

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_en.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_en.properties
@@ -34,7 +34,7 @@ login.login = Log in
 login.remember = Remember me
 login.logout = You are now logged out.
 login.error = Wrong username or password.
-login.insecure = {0} is not secured. Please log in with username and<br>password "admin", or click <a href="login.view?user=admin&amp;password=admin">here</a>. Then change password immediately.
+login.insecure = {0} is not secured. Please log in with username and<br>password "admin". Then change password immediately.
 login.recover = Forgotten your password?
 
 # recover.jsp

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_et.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_et.properties
@@ -34,7 +34,7 @@ login.login = Logi sisse
 login.remember = Mämind
 login.logout = Nüüd olete välja logitud.
 login.error = Kasutajanimi või parool on vale.
-login.insecure = {0} pole turvaline. Palun logi sisse kasutajanimega ja <br>parooliga "admin", või kliki <a href="login.view?user=admin&amp;password=admin">siia</a>. Peale seda muutke parool koheselt ära.
+login.insecure = {0} pole turvaline. Palun logi sisse kasutajanimega ja <br>parooliga "admin". Peale seda muutke parool koheselt ära.
 login.recover = Unustasite parooli?
 
 # recover.jsp

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_fi.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_fi.properties
@@ -29,7 +29,7 @@ login.login = Kirjaudu sis\u00E4\u00E4n
 login.remember = Muista minut
 login.logout = Olet nyt kirjautunut ulos.
 login.error = V\u00E4\u00E4r\u00E4 k\u00E4ytt\u00E4j\u00E4tunnus tai salasana.
-login.insecure = {0} profiili ei ole turvallinen. Kirjaudu sis\u00E4\u00E4n k\u00E4ytt\u00E4j\u00E4tunnuksella ja<br>salasanalla "admin", tai klikkaa <a href="login.view?user=admin&amp;password=admin">t\u00E4ss\u00E4</a>. Vaihda salasana v\u00E4litt\u00F6m\u00E4sti.
+login.insecure = {0} profiili ei ole turvallinen. Kirjaudu sis\u00E4\u00E4n k\u00E4ytt\u00E4j\u00E4tunnuksella ja<br>salasanalla "admin". Vaihda salasana v\u00E4litt\u00F6m\u00E4sti.
 
 # accessDenied.jsp
 accessDenied.title = P\u00E4\u00E4sy kielletty

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_is.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_is.properties
@@ -29,7 +29,7 @@ login.login = Innskr\u00E1
 login.remember = Muna Mig
 login.logout = \u00DE\u00FA ert n\u00FA \u00DAtskr\u00E1\u00F0ur.
 login.error = Rangt Notandanafn/Lykilor\u00F0.
-login.insecure = {0} er ekki \u00D6rugt. Vinsamlegast Innskr\u00E1\u00F0ur \u00FEig me\u00F0 Notandanafn og<br>Lykilor\u00F0 "admin", E\u00F0a smelltu <a href="login.view?user=admin&amp;password=admin">H\u00E9r</a>. Til a\u00F0 breyta Lykilor\u00F0inu Strax.
+login.insecure = {0} er ekki \u00D6rugt. Vinsamlegast Innskr\u00E1\u00F0ur \u00FEig me\u00F0 Notandanafn og<br>Lykilor\u00F0 "admin". Til a\u00F0 breyta Lykilor\u00F0inu Strax.
 
 # accessDenied.jsp
 accessDenied.title = A\u00F0gangi Hafna\u00F0

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_nl.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_nl.properties
@@ -40,7 +40,7 @@ login.login = Inloggen
 login.remember = Onthoud mij.
 login.logout = Je bent uitgelogd.
 login.error = Gebruikersnaam of wachtwoord onbekend.
-login.insecure = {0} is niet beveiligd. Log in met gebruikersnaam en<br>wachtwoord "admin", of klik <a href="login.view?user=admin&amp;password=admin">hier</a> en verander het wachtwoord onmiddelijk.
+login.insecure = {0} is niet beveiligd. Log in met gebruikersnaam en<br>wachtwoord "admin" en verander het wachtwoord onmiddelijk.
 login.recover = Wachtwoord vergeten?
 
 # recover.jsp

--- a/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_pt.properties
+++ b/libresonic-main/src/main/resources/org/libresonic/player/i18n/ResourceBundle_pt.properties
@@ -29,7 +29,7 @@ login.login = Iniciar sess\u00E3o
 login.remember = Manter sess\u00E3o iniciada
 login.logout = Est\u00E1 agora desligado.
 login.error = Utilizador ou senha errada.
-login.insecure = {0} n\u00E3o est\u00E1 seguro. Por favor inicie sess\u00E3o com o utilizador e<br>senha "admin", ou carregue <a href="login.view?user=admin&amp;password=admin">aqui</a>. Depois mude a senha imediatamente.
+login.insecure = {0} n\u00E3o est\u00E1 seguro. Por favor inicie sess\u00E3o com o utilizador e<br>senha "admin". Depois mude a senha imediatamente.
 
 # accessDenied.jsp
 accessDenied.title = Acesso negado


### PR DESCRIPTION
This fixes issue #334 for the following locales: ca da de en et fi is nl pt.
I have altered the wording of the second sentence in German too, as it was somewhat clumsy (switched from "friendly" to "formal" and included a capitalisation error).

The following translations still contain the broken link: bg cs el ja_JP ko pl sl zh_CN zh_TW