### PR TITLE
Bump jaudio tagger version

### DIFF
--- a/libresonic-main/pom.xml
+++ b/libresonic-main/pom.xml
@@ -194,9 +194,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org</groupId>
+            <groupId>net.jthink</groupId>
             <artifactId>jaudiotagger</artifactId>
-            <version>2.0.3</version>
+            <version>2.2.3</version>
         </dependency>
 
         <dependency>
@@ -397,6 +397,17 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.24</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.7</version>
         </dependency>
     </dependencies>
 

--- a/libresonic-main/src/main/java/org/libresonic/player/dao/MediaFileDao.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/dao/MediaFileDao.java
@@ -24,6 +24,7 @@ import org.libresonic.player.domain.Genre;
 import org.libresonic.player.domain.MediaFile;
 import org.libresonic.player.domain.MusicFolder;
 import org.libresonic.player.domain.RandomSearchCriteria;
+import org.libresonic.player.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
@@ -164,6 +165,8 @@ public class MediaFileDao extends AbstractDao {
                      "present=?, " +
                      "version=? " +
                      "where path=?";
+
+        logger.trace("Updating media file {}", Util.debugObject(file));
 
         int n = update(sql,
                        file.getFolder(), file.getMediaType().name(), file.getFormat(), file.getTitle(), file.getAlbumName(), file.getArtist(),

--- a/libresonic-main/src/main/java/org/libresonic/player/service/metadata/JaudiotaggerParser.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/metadata/JaudiotaggerParser.java
@@ -26,7 +26,7 @@ import org.jaudiotagger.audio.AudioFileIO;
 import org.jaudiotagger.audio.AudioHeader;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.Tag;
-import org.jaudiotagger.tag.datatype.Artwork;
+import org.jaudiotagger.tag.images.Artwork;
 import org.jaudiotagger.tag.reference.GenreTypes;
 import org.libresonic.player.Logger;
 import org.libresonic.player.domain.MediaFile;

--- a/libresonic-main/src/main/java/org/libresonic/player/util/Util.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/util/Util.java
@@ -19,12 +19,16 @@
  */
 package org.libresonic.player.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.libresonic.player.Logger;
 
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Miscellaneous general utility methods.
@@ -101,5 +105,15 @@ public final class Util {
             result[i] = values.get(i);
         }
         return result;
+    }
+
+    static ObjectMapper objectMapper = new ObjectMapper();
+    public static String debugObject(Object object) {
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            LOG.warn("Cant output debug object", e);
+            return "";
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
             <name>teleal</name>
             <url>http://teleal.org/m2</url>
         </repository>
+        <repository>
+            <id>jaudiotagger-repository</id>
+            <url>https://dl.bintray.com/ijabz/maven</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
Fixes #337.

In particular our current version of jaudio tagger does not split the null terminator into separate tag values, so it is possible to end up with something like `AlbumArtist1\0000AlbumArtist2`. Postgres in particular despises this. Across other databases, I imagine this value is just getting silently converted to `AlbumArtist1AlbumArtist2` although I have not tested this.

The upside is that the fix is easy, update JaudioTagger as the bug seems to be fixed in the most recent version. The downside of this is that I'm not sure of the impact of doing so especially since we are so close to releasing 6.2. Perhaps this might be a good candidate for a 6.2.1 release.

Signed-off-by: Andrew DeMaria <lostonamountain@gmail.com>