### PR TITLE
Proxy fixes

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/service/NetworkService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/NetworkService.java
@@ -60,8 +60,21 @@ public class NetworkService {
 
     private static URI calculateProxyUri(HttpServletRequest request) throws URISyntaxException {
         String xForardedHost = request.getHeader(X_FORWARDED_HOST);
+        // If the request has been through multiple reverse proxies,
+        // We need to return the original Host that the client used
+        if (xForardedHost != null) {
+            xForardedHost = xForardedHost.split(",")[0];
+        }
+
         if(!isValidXForwardedHost(xForardedHost)) {
             xForardedHost = request.getHeader(X_FORWARDED_SERVER);
+
+            // If the request has been through multiple reverse proxies,
+            // We need to return the original Host that the client used
+            if (xForardedHost != null) {
+                xForardedHost = xForardedHost.split(",")[0];
+            }
+
             if(!isValidXForwardedHost(xForardedHost)) {
                 throw new RuntimeException("Cannot calculate proxy uri without HTTP header " + X_FORWARDED_HOST);
             }


### PR DESCRIPTION
This fixes 2 issues with the current proxy handling:
1. If libresonic is behind multiple reverse proxies, the proxy headers would be ignored as other proxies will append their own headers.

2. Use the full URL when redirecting from nowPlaying.view.
Otherwise it could redirect from HTTPS to HTTP and then be blocked by the browser.