### PR TITLE
API: Fix crash when retrieving 0 documents

### DIFF
--- a/libresonic-main/src/main/java/org/libresonic/player/service/SearchService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/SearchService.java
@@ -159,6 +159,8 @@ public class SearchService {
         int count = criteria.getCount();
         result.setOffset(offset);
 
+        if (count <= 0) return result;
+
         IndexReader reader = null;
         try {
             reader = createIndexReader(indexType);


### PR DESCRIPTION
If an API client requests 0 documents when using one of the `search` methods, an exception is raised by Lucene, which litters the logs with this :

```
java.lang.IllegalArgumentException: nDocs must be > 0
        at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:164) ~[lucene-core-3.0.3.jar!/:3.0.3 1039909 - 2010-11-28 19:08:19]
        at org.apache.lucene.search.Searcher.search(Searcher.java:98) ~[lucene-core-3.0.3.jar!/:3.0.3 1039909 - 2010-11-28 19:08:19]
        at org.libresonic.player.service.SearchService.search(SearchService.java:183) ~[classes!/:6.3-SNAPSHOT]
        at org.libresonic.player.controller.RESTController.search2(RESTController.java:720) [classes!/:6.3-SNAPSHOT]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_121]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_121]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_121]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_121]
        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205) [spring-web-4.3.7.RELEASE.jar!/:4.3.7.RELEASE]
        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:133) [spring-web-4.3.7.RELEASE.jar!/:4.3.7.RELEASE]
        at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:116) [spring-webmvc-4.3.
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:827) [spring-webmvc-4.
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:738) [spring-webmvc-4.3.7.R
        at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:85) [spring-webmvc-4.3.7.RELEASE.jar!/:4.3.7.R
        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:963) [spring-webmvc-4.3.7.RELEASE.jar!/:4.3.7.RELEASE]
        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:897) [spring-webmvc-4.3.7.RELEASE.jar!/:4.3.7.RELEASE]
        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:970) [spring-webmvc-4.3.7.RELEASE.jar!/:4.3.7.RELEASE]
        at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:861) [spring-webmvc-4.3.7.RELEASE.jar!/:4.3.7.RELEASE]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:687) [javax.servlet-api-3.1.0.jar!/:3.1.0]
        at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:846) [spring-webmvc-4.3.7.RELEASE.jar!/:4.3.7.RELEASE]
...
```

DSub in particular seems to do this when syncing scrobbled songs after coming back from offline mode.