### PR TITLE
Fixing bad link to installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Libresonic can be downloaded from
 [GitHub](https://github.com/Libresonic/libresonic/releases) for personal usage.
 Packagers can also reference the [release repository](https://libresonic.org/release/).
 
-Please see the [INSTALL document](https://github.com/Libresonic/libresonic/blob/stable/documentation/INSTALL.md) for instructions on running Libresonic.
+Please see the [INSTALL document](https://github.com/Libresonic/documentation/blob/stable/install.md) for instructions on running Libresonic.
 
 
 Community


### PR DESCRIPTION
Was updating to v6.2 and noticed since the documentation was moved the link in README.md had not been updated.

Signed-off-by: Charles Schaack <CharlesSchaack@users.noreply.github.com>