### PR TITLE
CUE sheet support for single-track albums

### DIFF
--- a/libresonic-main/pom.xml
+++ b/libresonic-main/pom.xml
@@ -462,6 +462,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.8.7</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.carlwilson</groupId>
+            <artifactId>cuelib</artifactId>
+            <version>master-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/libresonic-main/src/main/java/org/libresonic/player/controller/RESTController.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/controller/RESTController.java
@@ -1288,6 +1288,9 @@ public class RESTController {
                 case MUSIC:
                     child.setType(MediaType.MUSIC);
                     break;
+                case MUSIC_SINGLE_FILE:
+                    child.setType(MediaType.MUSIC);
+                    break;
                 case PODCAST:
                     child.setType(MediaType.PODCAST);
                     break;

--- a/libresonic-main/src/main/java/org/libresonic/player/domain/MediaFile.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/domain/MediaFile.java
@@ -134,6 +134,9 @@ public class MediaFile {
 
     public File getFile() {
         // TODO: Optimize
+        if (mediaType.equals(MediaType.MUSIC_SINGLE_FILE)){
+            return new File(getSingleFileAlbumSongWholePath());
+        }
         return new File(path);
     }
 
@@ -154,7 +157,7 @@ public class MediaFile {
     }
 
     public boolean isAudio() {
-        return mediaType == MediaType.MUSIC || mediaType == MediaType.AUDIOBOOK || mediaType == MediaType.PODCAST;
+        return mediaType == MediaType.MUSIC || mediaType == MediaType.AUDIOBOOK || mediaType == MediaType.PODCAST || mediaType == MediaType.MUSIC_SINGLE_FILE;
     }
 
     public String getFormat() {
@@ -170,11 +173,11 @@ public class MediaFile {
     }
 
     public boolean isFile() {
-        return mediaType != MediaType.DIRECTORY && mediaType != MediaType.ALBUM;
+        return mediaType != MediaType.DIRECTORY && mediaType != MediaType.ALBUM && mediaType != MediaType.ALBUM_SINGLE_FILE;
     }
 
     public boolean isAlbum() {
-        return mediaType == MediaType.ALBUM;
+        return mediaType == MediaType.ALBUM || mediaType == MediaType.ALBUM_SINGLE_FILE;
     }
 
     public String getTitle() {
@@ -461,12 +464,33 @@ public class MediaFile {
         };
     }
 
+    public void setPathForSingleFileMedia(String mediaFilePath, int songStart, int songEnd) {
+        setPath(mediaFilePath + ":" + songStart + ":" + songEnd);
+    }
+
+    public String getSingleFileAlbumSongBegin(){
+        String[] parts = path.split(":");
+        return parts[parts.length-2];
+    }
+
+    public String getSingleFileAlbumSongEnd(){
+        String[] parts = path.split(":");
+        return parts[parts.length-1];
+    }
+
+    private String getSingleFileAlbumSongWholePath(){
+        String[] parts = path.split(":");
+        return parts[parts.length-3];
+    }
+
     public static enum MediaType {
         MUSIC,
         PODCAST,
         AUDIOBOOK,
         VIDEO,
         DIRECTORY,
-        ALBUM
+        ALBUM,
+        ALBUM_SINGLE_FILE,
+        MUSIC_SINGLE_FILE
     }
 }

--- a/libresonic-main/src/main/java/org/libresonic/player/service/MediaFileService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/MediaFileService.java
@@ -31,6 +31,10 @@ import org.libresonic.player.service.metadata.MetaData;
 import org.libresonic.player.service.metadata.MetaDataParser;
 import org.libresonic.player.service.metadata.MetaDataParserFactory;
 import org.libresonic.player.util.FileUtil;
+import org.opf_labs.audio.CueParser;
+import org.opf_labs.audio.CueSheet;
+import org.opf_labs.audio.Position;
+import org.opf_labs.audio.TrackData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -387,11 +391,21 @@ public class MediaFileService {
             storedChildrenMap.put(child.getPath(), child);
         }
 
-        List<File> children = filterMediaFiles(FileUtil.listFiles(parent.getFile()));
-        for (File child : children) {
-            if (storedChildrenMap.remove(child.getPath()) == null) {
-                // Add children that are not already stored.
-                mediaFileDao.createOrUpdateMediaFile(createMediaFile(child));
+        
+
+        if (parent.getMediaType() == ALBUM_SINGLE_FILE) {
+            for (MediaFile child: createSingleFileAlbumChildren(parent)){
+                if (storedChildrenMap.remove(child.getPath()) == null) {
+                    mediaFileDao.createOrUpdateMediaFile(child);
+                }
+            }
+        } else {
+            List<File> children = filterMediaFiles(FileUtil.listFiles(parent.getFile()));
+            for (File child : children) {
+                if (storedChildrenMap.remove(child.getPath()) == null) {
+                    // Add children that are not already stored.
+                    mediaFileDao.createOrUpdateMediaFile(createMediaFile(child));
+                }
             }
         }
 
@@ -404,6 +418,83 @@ public class MediaFileService {
         parent.setChildrenLastUpdated(parent.getChanged());
         parent.setPresent(true);
         mediaFileDao.createOrUpdateMediaFile(parent);
+    }
+
+    private List<MediaFile> createSingleFileAlbumChildren(MediaFile album) {
+        try {
+            List<MediaFile> childes = new ArrayList<>();
+            for (File cueFile : getCueSheets(album.getFile())) {
+                File soundFile = getSoundChild(album.getFile(), cueFile.getPath());
+                if (soundFile != null) {
+                    MetaDataParser parser = metaDataParserFactory.getParser(soundFile);
+                    MetaData metaData = null;
+                    if (parser != null) {
+                        metaData = parser.getMetaData(soundFile);
+                    }
+                    long wholeFileSize = FileUtil.length(soundFile);
+                    int wholeFileLength = 0; //todo: find sound length without metadata
+                    if (metaData != null) {
+                        wholeFileLength = metaData.getDurationSeconds();
+                    }
+                    CueSheet cueSheet = CueParser.parse(cueFile);
+                    for (int i = 0; i < cueSheet.getAllTrackData().size(); i++) {
+                        TrackData trackData = cueSheet.getAllTrackData().get(i);
+                        MediaFile mediaFile = new MediaFile();
+                        mediaFile.setMediaType(MUSIC_SINGLE_FILE);
+                        mediaFile.setAlbumArtist(cueSheet.getPerformer());
+                        mediaFile.setAlbumName(cueSheet.getTitle());
+                        mediaFile.setTitle(trackData.getTitle());
+                        mediaFile.setArtist(trackData.getPerformer());
+                        mediaFile.setParentPath(album.getPath());
+                        Date lastModified = new Date(FileUtil.lastModified(soundFile));
+                        MediaFile existingFile = mediaFileDao.getMediaFile(mediaFile.getPath());
+                        mediaFile.setFolder(securityService.getRootFolderForFile(soundFile));
+                        mediaFile.setChanged(lastModified);
+                        mediaFile.setLastScanned(new Date());
+                        mediaFile.setPlayCount(existingFile == null ? 0 : existingFile.getPlayCount());
+                        mediaFile.setLastPlayed(existingFile == null ? null : existingFile.getLastPlayed());
+                        mediaFile.setComment(existingFile == null ? null : existingFile.getComment());
+                        mediaFile.setChildrenLastUpdated(new Date(0));
+                        mediaFile.setCreated(lastModified);
+                        mediaFile.setPresent(true);
+                        mediaFile.setTrackNumber(trackData.getNumber());
+
+                        if (metaData != null) {
+                            mediaFile.setDiscNumber(metaData.getDiscNumber());
+                            mediaFile.setGenre(metaData.getGenre());
+                            mediaFile.setYear(metaData.getYear());
+                            mediaFile.setBitRate(metaData.getBitRate());
+                            mediaFile.setVariableBitRate(metaData.getVariableBitRate());
+                            mediaFile.setHeight(metaData.getHeight());
+                            mediaFile.setWidth(metaData.getWidth());
+                        }
+
+                        String format = StringUtils.trimToNull(StringUtils.lowerCase(FilenameUtils.getExtension(soundFile.getPath())));
+                        mediaFile.setFormat(format);
+
+                        Position currentPosition = cueSheet.getAllTrackData().get(i).getIndices().get(0).getPosition();
+                        int currentStart = currentPosition.getMinutes() * 60 + currentPosition.getSeconds();
+
+                        int nextStart = 0;
+                        if (cueSheet.getAllTrackData().size() - 1 != i) {
+                            Position nextPosition = cueSheet.getAllTrackData().get(i + 1).getIndices().get(0).getPosition();
+                            nextStart = nextPosition.getMinutes() * 60 + nextPosition.getSeconds();
+                        } else {
+                            nextStart = wholeFileLength;
+                        }
+
+                        mediaFile.setDurationSeconds(nextStart - currentStart);
+                        mediaFile.setPathForSingleFileMedia(soundFile.getPath(), currentStart, nextStart);
+                        mediaFile.setFileSize((long) ((float) mediaFile.getDurationSeconds() / wholeFileLength * wholeFileSize)); //approximate
+
+                        childes.add(mediaFile);
+                    }
+                }
+            }
+            return childes;
+        } catch (IOException e) {
+            return Collections.emptyList();
+        }
     }
 
     public List<File> filterMediaFiles(File[] candidates) {
@@ -530,10 +621,48 @@ public class MediaFileService {
                 } else {
                     mediaFile.setArtist(file.getName());
                 }
+                
+                if (isSingleFileAlbum(file)){
+                    mediaFile.setMediaType(ALBUM_SINGLE_FILE);
+                }
             }
         }
 
         return mediaFile;
+    }
+
+    private boolean isSingleFileAlbum(File albumDir) {
+        for (File cueFile : getCueSheets(albumDir)) {
+            if (getSoundChild(albumDir, cueFile.getPath()) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private List<File> getCueSheets(File albumDir){
+        List<File> cueFiles = new ArrayList<>();
+        for (File child:FileUtil.listFiles(albumDir)){
+            if (isCueSheet(child)){
+                cueFiles.add(child);
+            }
+        }
+        return cueFiles;
+    }
+    
+    private File getSoundChild(File albumDir, String cueFilePath){
+        List<File> candidates = filterMediaFiles(FileUtil.listFiles(albumDir));
+        for (File singleFileSound:candidates){
+            if (FilenameUtils.getBaseName(singleFileSound.getPath()).equals(FilenameUtils.getBaseName(cueFilePath))||
+                    FilenameUtils.getName(singleFileSound.getPath()).equals(FilenameUtils.getBaseName(cueFilePath))) {
+                return singleFileSound;
+            }
+        }
+        return null;
+    }
+    
+    private boolean isCueSheet(File file){
+        return "cue".equalsIgnoreCase(FilenameUtils.getExtension(file.getName()));
     }
 
     private MediaFile.MediaType getMediaType(MediaFile mediaFile) {

--- a/libresonic-main/src/main/java/org/libresonic/player/service/TranscodingService.java
+++ b/libresonic-main/src/main/java/org/libresonic/player/service/TranscodingService.java
@@ -331,6 +331,23 @@ public class TranscodingService {
 
         for (int i = 1; i < result.size(); i++) {
             String cmd = result.get(i);
+
+            if (cmd.contains("%ss")) {
+                if (mediaFile.getMediaType().equals(MediaFile.MediaType.MUSIC_SINGLE_FILE)) {
+                    cmd = cmd.replace("%ss", mediaFile.getSingleFileAlbumSongBegin());
+                } else {
+                    cmd = cmd.replace("%ss", "0");
+                }
+            }
+
+            if (cmd.contains("%to")) {
+                if (mediaFile.getMediaType().equals(MediaFile.MediaType.MUSIC_SINGLE_FILE)) {
+                    cmd = cmd.replace("%to", mediaFile.getSingleFileAlbumSongEnd());
+                } else {
+                    cmd = cmd.replace("%to", "" + mediaFile.getDurationSeconds());
+                }
+            }
+            
             if (cmd.contains("%b")) {
                 cmd = cmd.replace("%b", String.valueOf(maxBitRate));
             }

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
             <id>jaudiotagger-repository</id>
             <url>https://dl.bintray.com/ijabz/maven</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
This is implementation of support for single file album with cue file. 

Path of song from single-file album is stored as 
```
<whole file path>:<seconds from begin of file where song starts>:<seconds from begin of file where song ends>
```

Also there are two new params in transcoding string: %ss and %to, which represents same begin and end seconds of song. So example string for ffmpeg will look like this: 
```
ffmpeg -ss %ss -i %s -to %to -map 0:0 -b:a %bk -v 0 -f mp3 -
```

Parsing of .cue file is done with [cuelib](https://github.com/carlwilson/cuelib). I was not able to found it no maven central, so used [jitpack](https://jitpack.io)

